### PR TITLE
[Auto Updating] Fix Linux Auto Updates in 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.1]
+
+### Linux Auto Updates
+
+* Linux auto updates should properly work from this release (1.6.1) and on. 
+
 ## [1.6.0]
 
 ### Updated Spell Animations!

--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "spire",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Akkadius/spire.git"
-  },
-  "dependencies": {
-    "vue-color": "^2.8.1"
   }
 }


### PR DESCRIPTION
## [1.6.1]

### Linux Auto Updates

* Linux auto updates should properly work from this release (1.6.1) and on. 
