### PR TITLE
[UI Tweaks] Remove Raw Item Icon Assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [1.6.6]
+
+### UI Tweaks
+
+All item icons in application now load from a spritesheet, removing the dependency on an additional set of 40MB of images being loaded into the binary
+
 ## [1.6.5]
 
 ### Quest API Explorer

--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ build-assets: ##@build Builds static assets before packing into binary
 strip-extra-assets: ##@build Strips extra assets not needed to packet into binary
 	rm -rf frontend/public/eq-asset-preview-master/assets/npc_models
 	rm -rf frontend/public/eq-asset-preview-master/assets/objects
+	rm -rf frontend/public/eq-asset-preview-master/assets/item_icons
 
 build-frontend: ##@build Builds frontend to be packed into binary
 	cd frontend && npm install && npm run build

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -15,6 +15,7 @@
     <meta name="MobileOptimized" content="320">
 
     <link rel="stylesheet" href="/eq-asset-preview-master/assets/sprites/item-icons.css">
+    <link rel="stylesheet" href="/eq-asset-preview-master/assets/sprites/item-icons-sm.css">
     <link rel="stylesheet" href="/eq-asset-preview-master/assets/sprites/objects.css">
     <link rel="stylesheet" href="/eq-asset-preview-master/assets/sprites/race-models.css">
 

--- a/frontend/src/app/spells.ts
+++ b/frontend/src/app/spells.ts
@@ -252,10 +252,7 @@ export class Spells {
                 <div :id="${parentSpellIdSi} + '-' + ${effectIndex} + '-' + ${item.id} + '-' + componentId" style="display:inline-block">
 
                   <div style="display: inline-block">
-                    <img
-                      :src="itemCdnUrl + 'item_' + ${item.icon} + '.png'"
-                      style="height:15px; border-radius: 25px; width:auto;"
-                      class="mr-1">
+                    <div class="ml-1 item-${item.icon}-sm"/>
                     <span class="mr-1">${item.name}</span>
                   </div>
 
@@ -641,10 +638,7 @@ export class Spells {
                 <div :id="${parentSpellId} + '-' + ${effectIndex} + '-' + ${item2.id} + '-' + componentId" style="display:inline-block">
 
                   <div style="display: inline-block">
-                    <img
-                      :src="itemCdnUrl + 'item_' + ${item2.icon} + '.png'"
-                      style="height:15px; border-radius: 25px; width:auto;"
-                      class="mr-1">
+                    <div class="ml-1 item-${item2.icon}-sm"/>
                     <span class="mr-1">${item2.name}</span>
                   </div>
 
@@ -2981,9 +2975,12 @@ export class Spells {
     }
   };
 
-  public static async renderSpellMini(parentSpellId, renderSpellId, iconSize = 20) {
+  public static async renderSpellMini(parentSpellId, renderSpellId, iconSize = 16) {
     let spell             = <any>await this.getSpell(renderSpellId)
     const targetTypeColor = this.getTargetTypeColor(spell["targettype"]);
+
+    let borderSize = iconSize > 16 ? 2 : 1;
+    let borderRadius = iconSize > 16 ? 7 : 3;
 
     return `
           <div :id="${parentSpellId} + '-' + ${renderSpellId} + '-' + componentId" style="display:inline-block">
@@ -2991,8 +2988,8 @@ export class Spells {
             <div style="display: inline-block">
               <img
                 :src="spellCdnUrl + '' + (${spell.new_icon} > 0 ? ${spell.new_icon} : 1) + '.gif'"
-                style="width: ${iconSize}px;height:auto; border: 2px solid ${targetTypeColor}; border-radius: 7px;"
-                :class="(${iconSize} > 20 ? 'mr-1' : '')"
+                style="width: ${iconSize}px;height:auto; border: ${borderSize}px solid ${targetTypeColor}; border-radius: ${borderRadius}px;"
+                :class="(${iconSize} > 16 ? 'mr-1' : '')"
                 >
               <span style="color: #f7ff00">${spell.name}</span>
             </div>

--- a/frontend/src/assets/css/global.css
+++ b/frontend/src/assets/css/global.css
@@ -193,13 +193,27 @@
     animation: pulsate-highlight-modified 2s infinite;
 }
 
+
 .hover-highlight:hover {
     border: 2px solid rgb(218 218 218 / 0%);
     border-radius: 7px;
 }
 
+/*first used with sprites / item icons */
+.hover-highlight-inner:hover {
+    /*box-shadow: inset 10px 0 0 0px white;*/
+    opacity: 1 !important;
+    box-shadow:inset 0 0 7px white;
+}
+
+.highlight-selected-inner {
+    /*box-shadow: inset 10px 0 0 0px white;*/
+    border: .5px solid white;
+    box-shadow:inset 0 0 7px white;
+}
+
 .dropdown-menu {
-    background-color: #0b0b10;
+    /*background-color: #0b0b10;*/
 }
 
 /* if inputs are children of element with class */

--- a/frontend/src/components/eq-ui/EQItemCardPreview.vue
+++ b/frontend/src/components/eq-ui/EQItemCardPreview.vue
@@ -199,8 +199,6 @@
       </div>
     </div>
 
-    <!-- TODO: Price -->
-
     <!-- Extra Damage Amount -->
     <div v-if="itemData['extradmgamt'] > 0" class="mt-3 mb-3 row">
       <div class="col-12">

--- a/frontend/src/components/eq-ui/EQSpellCardPreview.vue
+++ b/frontend/src/components/eq-ui/EQSpellCardPreview.vue
@@ -1,11 +1,15 @@
 <template>
-  <div class="pb-4 fade-in" style="min-width: 400px; max-width: 500px; padding: 5px"
-       v-if="spellData && spellData['targettype']">
+  <div
+    class="pb-4 fade-in" style="min-width: 400px; max-width: 500px; padding: 5px"
+    v-if="spellData && spellData['targettype']"
+  >
 
     <div class="row">
       <div class="col-1">
-        <img :src="spellCdnUrl + (spellData.new_icon > 0 ? spellData.new_icon : 1) + '.gif'"
-             :style="'width:40px;height:auto;border-radius: 10px; ' + 'border: 2px solid ' + getTargetTypeColor(this.spellData['targettype']) + '; border-radius: 7px;'">
+        <img
+          :src="spellCdnUrl + (spellData.new_icon > 0 ? spellData.new_icon : 1) + '.gif'"
+          :style="'width:40px;height:auto;border-radius: 10px; ' + 'border: 2px solid ' + getTargetTypeColor(this.spellData['targettype']) + '; border-radius: 7px;'"
+        >
       </div>
       <div class="col-11 pl-5">
         <h6 class="eq-header" style="margin: 0px; margin-bottom: 10px">
@@ -30,12 +34,15 @@
         <td class="spell-field-label">Classes</td>
         <td style="width: 250px">
           <div v-for="(icon, index) in dbClassIcons" style="display: inline-block">
-            <div v-if="spellData['classes_' + index] > 0 && spellData['classes_' + index] < 255"
-                 class="mr-2">
-              <img
-                :src="itemCdnUrl + 'item_' + icon + '.png'"
-                class="mb-1"
-                style="height: 17px; width:auto; border-radius: 5px">
+            <div
+              v-if="spellData['classes_' + index] > 0 && spellData['classes_' + index] < 255"
+              class="mr-2"
+            >
+               <span
+                 style="border-radius: 4px"
+                 :class="'item-' + icon + '-sm'"
+                 :title="dbClassesShort[index]"
+               />
               {{ dbClassesShort[index] }}
               ({{ spellData["classes_" + index] }})
             </div>
@@ -68,7 +75,9 @@
       <tr v-if="spellData['typedescnum'] !== ''">
         <td class="spell-field-label">Book Category</td>
         <td> {{ getSpellTypeDescNumName(spellData["typedescnum"]) }}
-          <span v-if="spellData['effectdescnum'] !== ''"> / {{ getSpellTypeDescNumName(spellData["effectdescnum"]) }} </span>
+          <span v-if="spellData['effectdescnum'] !== ''"> / {{
+              getSpellTypeDescNumName(spellData["effectdescnum"])
+            }} </span>
         </td>
       </tr>
 
@@ -152,14 +161,16 @@
       <!-- Casting -->
 
       <tr
-        v-if="(spellData['cast_time'] > 0 || spellData['recovery_time'] > 0 || spellData['recast_time'] > 0) && spellData['is_discipline'] === 0">
+        v-if="(spellData['cast_time'] > 0 || spellData['recovery_time'] > 0 || spellData['recast_time'] > 0) && spellData['is_discipline'] === 0"
+      >
         <td class="spell-field-label">Casting Time</td>
         <td> {{ (spellData["cast_time"] / 1000) }} sec
           <span v-if="spellData['uninterruptable'] !== 0">(Uninterruptable)</span>
         </td>
       </tr>
       <tr
-        v-if="(spellData['cast_time'] > 0 || spellData['recovery_time'] > 0 || spellData['recast_time'] > 0) && spellData['is_discipline'] === 0">
+        v-if="(spellData['cast_time'] > 0 || spellData['recovery_time'] > 0 || spellData['recast_time'] > 0) && spellData['is_discipline'] === 0"
+      >
         <td class="spell-field-label">Recovery Time</td>
         <td> {{ (spellData["recovery_time"] / 1000) }} sec</td>
       </tr>
@@ -222,7 +233,8 @@
         </td>
       </tr>
       <tr
-        v-if="(spellData['max_dist'] !== 0 || spellData['min_dist'] !== 0) && (spellData['max_dist_mod'] !== 0 || spellData['min_dist_mod'] !== 0) ">
+        v-if="(spellData['max_dist'] !== 0 || spellData['min_dist'] !== 0) && (spellData['max_dist_mod'] !== 0 || spellData['min_dist_mod'] !== 0) "
+      >
         <td class="spell-field-label">Range Based Mod</td>
         <td> ({{ spellData["min_dist_mod"] * 100 }}% at {{ spellData["min_dist"] }}') to
           ({{ spellData["max_dist_mod"] * 100 }}% at {{ spellData["max_dist"] }}')
@@ -240,9 +252,11 @@
         <td class="spell-field-label">Target</td>
         <td> {{ getTargetTypeName(spellData["targettype"]) }}
           <span
-            v-if="spellData['can_mgb'] == 0 && (spellData['buffduration'] > 0) && (spellData['targettype'] === 3  || spellData['targettype'] === 40 || spellData['targettype'] === 41)"> &nbsp; (No MGB)</span>
+            v-if="spellData['can_mgb'] == 0 && (spellData['buffduration'] > 0) && (spellData['targettype'] === 3  || spellData['targettype'] === 40 || spellData['targettype'] === 41)"
+          > &nbsp; (No MGB)</span>
           <span
-            v-if="spellData['can_mgb'] === 1 && (spellData['buffduration'] === 0) && (spellData['targettype'] === 3  || spellData['targettype'] === 40 || spellData['targettype'] === 41)"> &nbsp; (Can MGB)</span>
+            v-if="spellData['can_mgb'] === 1 && (spellData['buffduration'] === 0) && (spellData['targettype'] === 3  || spellData['targettype'] === 40 || spellData['targettype'] === 41)"
+          > &nbsp; (Can MGB)</span>
         </td>
       </tr>
       <tr v-if="spellData['aemaxtargets'] > 0 ">
@@ -259,11 +273,13 @@
         <td class="spell-field-label">Resist Type</td>
         <td> {{ getSpellResistTypeName(spellData["resisttype"]) }}
           <span
-            v-if="spellData['resist_diff'] !== 0 && spellData['field_209'] === 0  && spellData['no_partial_resist'] === 0"> &nbsp;({{
+            v-if="spellData['resist_diff'] !== 0 && spellData['field_209'] === 0  && spellData['no_partial_resist'] === 0"
+          > &nbsp;({{
               spellData["resist_diff"]
             }})</span>
           <span
-            v-if="spellData['resist_diff'] !== 0 && spellData['field_209'] === 0  && spellData['no_partial_resist'] !== 0"> &nbsp;({{
+            v-if="spellData['resist_diff'] !== 0 && spellData['field_209'] === 0  && spellData['no_partial_resist'] !== 0"
+          > &nbsp;({{
               spellData["resist_diff"]
             }}) &nbsp; (No Partial Resist)</span>
           <span v-if="spellData['field_209'] !== 0">(Unresistable)</span>
@@ -353,7 +369,8 @@
         <v-runtime-template
           :template="'<span>' + effect + '</span>'"
           v-if="typeof effect !== 'undefined'"
-          class="pb-6 mt-3 doc"/>
+          class="pb-6 mt-3 doc"
+        />
       </div>
     </div>
 
@@ -364,10 +381,9 @@
         <div :id="reagent.id + '-' + reagent.item.id + '-' + componentId" style="display:inline-block">
 
           <div style="display: inline-block">
-            <img
-              :src="itemCdnUrl + 'item_' + reagent.item.icon + '.png'"
-              style="height:15px; border-radius: 25px; width:auto;"
-              class="mr-2">
+
+            <div :class="'ml-1 item-' + reagent.item.icon + '-sm'"/>
+
             <span class="mr-1">{{ reagent.item.name }}</span>
           </div>
 
@@ -441,7 +457,6 @@ export default {
       debug: App.DEBUG,
       debugSpellEffects: false,
       spellCdnUrl: App.ASSET_SPELL_ICONS_BASE_URL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       spellEffectInfo: [],
       itemData: {},
       sideLoadedSpellData: {},

--- a/frontend/src/components/eq-ui/EQSpellEffects.vue
+++ b/frontend/src/components/eq-ui/EQSpellEffects.vue
@@ -61,7 +61,6 @@ export default {
     return {
       spellEffectInfo: [],
       spellCdnUrl: App.ASSET_SPELL_ICONS_BASE_URL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       componentId: "",
       sideLoadedSpellData: {},
       loaded: false,

--- a/frontend/src/components/eq-ui/EQSpellPreviewTable.vue
+++ b/frontend/src/components/eq-ui/EQSpellPreviewTable.vue
@@ -1,7 +1,9 @@
 <template>
   <div>
-    <div class='eq-window'
-         :style="'margin-bottom: 40px; min-height: 275px; ' + (title ? 'padding-top: 30px' : 'padding-top: 0px !important')">
+    <div
+      class='eq-window'
+      :style="'margin-bottom: 40px; min-height: 275px; ' + (title ? 'padding-top: 30px' : 'padding-top: 0px !important')"
+    >
       <div class='eq-window-title-bar' v-if="title">{{ title }}</div>
       <div :style="'padding: 10px; ' + (title ? 'margin-top: 10px' : '') ">
         <div class='eq-window-nested-blue text-center' v-if="spells.length === 0">
@@ -41,20 +43,25 @@
                 </b-button>
               </td>
               <td>
-                {{spell.id}}
+                {{ spell.id }}
               </td>
               <td class="text-left">
                 <v-runtime-template
                   v-if="spellMinis"
-                  :template="'<span>' + spellMinis[spell.id] + '</span>'"/>
+                  :template="'<span>' + spellMinis[spell.id] + '</span>'"
+                />
               </td>
               <td class="text-left">
                 <span v-for="(icon, index) in dbClassIcons">
-                  <div v-if="spell['classes_' + index] > 0 && spell['classes_' + index] < 255" class="d-inline-block mr-2">
-                      <img
-                        :src="itemCdnUrl + 'item_' + icon + '.png'"
-                        class="mb-1"
-                        style="height: 17px; width:auto; border-radius: 5px">
+                  <div
+                    v-if="spell['classes_' + index] > 0 && spell['classes_' + index] < 255"
+                    class="d-inline-block mr-2"
+                  >
+                      <span
+                        style="border-radius: 4px"
+                        :class="'item-' + icon + '-sm'"
+                        :title="dbClassesShort[index]"
+                      />
                     {{ dbClassesShort[index] }}
                     ({{ spell["classes_" + index] }})
                     </div>
@@ -71,9 +78,9 @@
               <td> {{ getTargetTypeName(spell["targettype"]) }}</td>
 
 
-<!--              <td style="text-align: left">-->
-<!--                <eq-spell-description :spell="spell"/>-->
-<!--              </td>-->
+              <!--              <td style="text-align: left">-->
+              <!--                <eq-spell-description :spell="spell"/>-->
+              <!--              </td>-->
             </tr>
             </tbody>
           </table>
@@ -110,7 +117,6 @@ export default {
       debug: App.DEBUG,
       debugSpellEffects: false,
       spellCdnUrl: App.ASSET_SPELL_ICONS_BASE_URL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       spellEffectInfo: [],
       itemData: {},
       sideLoadedSpellData: {},

--- a/frontend/src/components/eq-ui/EQSpellPreviewTableSelector.vue
+++ b/frontend/src/components/eq-ui/EQSpellPreviewTableSelector.vue
@@ -38,12 +38,12 @@
           >
                 <span v-for="(icon, index) in dbClassIcons">
                   <div v-if="spell['classes_' + index] > 0 && spell['classes_' + index] < 255">
-                      <img
-                        :src="itemCdnUrl + 'item_' + icon + '.png'"
-                        class="mb-1"
-                        style="height: 17px; width:auto; border-radius: 5px"
-                        alt=""
-                      >
+                    
+                     <span
+                       style="border-radius: 4px"
+                       :class="'item-' + icon + '-sm'"
+                       :title="dbClassesShort[index]"
+                     />
                     {{ dbClassesShort[index] }}
                     ({{ spell["classes_" + index] }})
                     </div>

--- a/frontend/src/components/eq-ui/EqCashDisplay.vue
+++ b/frontend/src/components/eq-ui/EqCashDisplay.vue
@@ -1,22 +1,22 @@
 <template>
   <div>
     <div v-if="platinum > 0" class="d-inline-block mr-2">
-      <img :src="cdnUrl + 'assets/item_icons/item_644.png'" :style="'height: ' + size + 'px'" title="Platinum">
+      <div :class="'ml-1 item-644-sm'" title="Silver"/>
       {{ platinum }}
     </div>
 
     <div v-if="gold > 0" class="d-inline-block mr-2">
-      <img :src="cdnUrl + 'assets/item_icons/item_645.png'" :style="'height: ' + size + 'px'" title="Gold">
+      <div :class="'ml-1 item-645-sm'" title="Silver"/>
       {{ gold }}
     </div>
 
     <div v-if="silver > 0" class="d-inline-block mr-2">
-      <img :src="cdnUrl + 'assets/item_icons/item_646.png'" :style="'height: ' + size + 'px'" title="Silver">
+      <div :class="'ml-1 item-646-sm'" title="Silver"/>
       {{ silver }}
     </div>
 
     <div v-if="copper > 0" class="d-inline-block mr-2">
-      <img :src="cdnUrl + 'assets/item_icons/item_647.png'" :style="'height: ' + size + 'px'" title="Copper">
+      <div :class="'ml-1 item-647-sm'" title="Copper"/>
       {{ copper }}
     </div>
   </div>

--- a/frontend/src/components/tools/ClassBitmaskCalculator.vue
+++ b/frontend/src/components/tools/ClassBitmaskCalculator.vue
@@ -4,22 +4,26 @@
       class="ml-1 mr-3 d-inline-block"
       :style="(centeredButtons ? 'width: 100%; margin: 0;' : '')"
     >
-      <div v-for="(gClass, classId) in classes" class="mb-1 d-inline-block">
+      <div v-for="(gClass, classId) in classes" class="d-inline-block">
         <div class="text-center p-0 mr-1 col-lg-12 col-sm-12">
           <span v-if="showTextTop">{{ gClass.short }}</span>
           <div class="text-center">
-            <img
+            <span
               :title="gClass.class"
               @click="selectClass(classId)"
-              :src="itemCdnUrl + 'item_' + gClass.icon + '.png'"
-              :style="getImageSize() + (isClassSelected(classId) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border-radius: 7px; opacity: .6')"
-              class="hover-highlight">
+              :style="(isClassSelected(classId) ? 'border-radius: 3px;' : 'border-radius: 3px; opacity: .6')"
+              :class="'hover-highlight-inner item-' + gClass.icon + ' ' + (isClassSelected(classId) ? 'highlight-selected-inner' : '')"
+            />
           </div>
         </div>
       </div>
 
       <!-- Select All / None -->
-      <div class="d-inline-block" v-if="displayAllNone">
+      <div
+        class="d-inline-block"
+        v-if="displayAllNone"
+        :style="'line-height: 25px; bottom: ' + (centeredButtons ? -10 : 15) + 'px; position: relative;'"
+      >
         <div
           :class="'text-center mt-2 btn-xs eq-button-fancy ' + (parseInt(mask) >= 65535 && !this.isOnlySelectedAndEnabled() ? 'eq-button-fancy-highlighted' : '')"
           @click="selectAll()"
@@ -82,11 +86,6 @@ export default {
       required: false,
       default: false
     },
-    imageSize: {
-      type: Number,
-      required: false,
-      default: 50,
-    },
     addOnlyButtonEnabled: {
       type: Boolean,
       required: false,
@@ -111,7 +110,6 @@ export default {
   data() {
     return {
       classes: DB_PLAYER_CLASSES_ALL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       selectedClasses: {},
       currentMask: 0,
       onlySelected: false,
@@ -131,10 +129,6 @@ export default {
     this.calculateFromBitmask();
   },
   methods: {
-    getImageSize() {
-      return util.format("width: %spx; height %spx;", this.imageSize, this.imageSize)
-    },
-
     isOnlySelectedAndEnabled() {
       return this.addOnlyButtonEnabled && this.onlySelected
     },
@@ -203,7 +197,7 @@ export default {
     },
     isClassSelected: function (classId) {
       return this.selectedClasses[classId]
-    }
+    },
   }
 }
 </script>

--- a/frontend/src/components/tools/DeityCalculator.vue
+++ b/frontend/src/components/tools/DeityCalculator.vue
@@ -4,26 +4,29 @@
       class="mr-3 d-inline-block text-center"
       :style="(centeredButtons ? 'width: 100%' : '')"
     >
-      <div v-for="(deity, deityId) in deities" class="mb-1 text-center d-inline-block">
+      <div v-for="(deity, deityId) in deities" class="text-center d-inline-block">
         <div class="text-center pl-0 pr-0 mr-1 col-lg-12 col-sm-12">
           <small
             :style="(deity.short.length > 8 ? 'font-size: 9px' : 'font-size: 11px')"
             v-if="showNames"
           >{{ deity.short }}</small>
           <div class="text-center">
-            <img
+            <span
               :title="deity.name"
               @click="selectDeity(deityId)"
-              :src="itemCdnUrl + 'item_' + deity.icon + '.png'"
-              :style="getImageSize() + ' ' + (isDeitySelected(deityId) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border-radius: 7px; opacity: .6')"
-              class="mt-1 hover-highlight" alt=""
-            >
+              :style="(isDeitySelected(deityId) ? 'border-radius: 3px;' : 'border-radius: 3px; opacity: .6')"
+              :class="'hover-highlight-inner item-' + deity.icon + ' ' + (isDeitySelected(deityId) ? 'highlight-selected-inner' : '')"
+            />
           </div>
         </div>
       </div>
 
       <!-- Select All / None -->
-      <div class="d-inline-block" v-if="displayAllNone">
+      <div
+        class="d-inline-block"
+        v-if="displayAllNone"
+        :style="'line-height: 25px; bottom: ' + (centeredButtons ? -10 : 15) + 'px; position: relative;'"
+      >
         <div
           :class="'text-center mt-2 btn-xs eq-button-fancy ' + (parseInt(mask) >= 65535 ? 'eq-button-fancy-highlighted' : '')"
           @click="selectAll()"
@@ -73,11 +76,6 @@ export default {
       required: false,
       default: true
     },
-    imageSize: {
-      type: Number,
-      required: false,
-      default: 50,
-    }
   },
   watch: {
     mask: {
@@ -92,7 +90,6 @@ export default {
   data() {
     return {
       deities: DB_DIETIES_FULL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       selectedDeityes: {},
       currentMask: 0
     }
@@ -102,9 +99,6 @@ export default {
     this.calculateFromBitmask();
   },
   methods: {
-    getImageSize() {
-      return util.format("width: %spx; height %spx;", this.imageSize, this.imageSize)
-    },
     selectAll() {
       Object.keys(this.deities).reverse().forEach((deityId) => {
         this.selectedDeityes[deityId] = true;

--- a/frontend/src/components/tools/ExpansionsCalculator.vue
+++ b/frontend/src/components/tools/ExpansionsCalculator.vue
@@ -3,13 +3,14 @@
     <div v-for="(expansion, expansionId) in expansions" class="row col-12">
       <div class="col-lg-12 col-sm-12" @click="selectExpansion(expansionId)">
         <div class="text-center" style="width: 70px; display: inline-block;">
-        <img
-          :src="getExpansionIconUrlSmall(expansionId)"
-          :style="'width: 56px;' + (isExpansionSelected(expansionId) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border: 2px solid rgb(218 218 218 / 30%); border-radius: 7px;')"
-          class="mt-1 p-1">
+          <img
+            :src="getExpansionIconUrlSmall(expansionId)"
+            :style="'width: 56px;' + (isExpansionSelected(expansionId) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border: 2px solid rgb(218 218 218 / 30%); border-radius: 7px;')"
+            class="mt-1 p-1"
+          >
         </div>
-          ({{expansionId}})
-          {{ expansion.name }}
+        ({{ expansionId }})
+        {{ expansion.name }}
       </div>
     </div>
     <div class="form-group text-center">
@@ -20,9 +21,8 @@
 </template>
 
 <script>
-import {App} from "../../constants/app";
 import {EXPANSIONS_FULL} from "../../app/constants/eq-expansions";
-import expansions from "../../app/utility/expansions";
+import expansions        from "../../app/utility/expansions";
 
 export default {
   name: "ExpansionBitmaskCalculator",
@@ -49,7 +49,6 @@ export default {
   data() {
     return {
       expansions: EXPANSIONS_FULL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       selectedExpansiones: {},
       currentMask: 0
     }
@@ -78,7 +77,7 @@ export default {
     },
     calculateFromBitmask() {
       Object.keys(this.expansions).reverse().forEach((expansionId) => {
-        const gameExpansion               = this.expansions[expansionId];
+        const gameExpansion                   = this.expansions[expansionId];
         this.selectedExpansiones[expansionId] = false
         if (this.currentMask >= gameExpansion.mask) {
           this.currentMask -= gameExpansion.mask;

--- a/frontend/src/components/tools/RaceBitmaskCalculator.vue
+++ b/frontend/src/components/tools/RaceBitmaskCalculator.vue
@@ -4,22 +4,25 @@
       class="ml-1 mr-3 d-inline-block text-center"
       :style="(centeredButtons ? 'width: 100%' : '')"
     >
-      <div v-for="(race, index) in races" class="mb-1 text-center d-inline-block">
+      <div v-for="(race, index) in races" class="text-center d-inline-block">
         <div class="text-center p-0 mr-1 col-lg-12 col-sm-12">
           <span v-if="showTextTop">{{ race.short }}</span>
           <div class="text-center">
-            <img
+            <span
               :title="race.race"
               @click="selectRace(index)"
-              :src="itemCdnUrl + 'item_' + race.icon + '.png'"
-              :style="getImageSize() + (isRaceSelected(index) ? 'border-radius: 7px; box-shadow: 0px 0px 1px 1px white;' : 'border-radius: 7px; opacity: .5')"
-              class="hover-highlight">
+              :style="(isRaceSelected(index) ? 'border-radius: 3px;' : 'border-radius: 3px; opacity: .6')"
+              :class="'hover-highlight-inner item-' + race.icon + ' ' + (isRaceSelected(index) ? 'highlight-selected-inner' : '')"
+            />
           </div>
         </div>
       </div>
 
       <!-- Select All / None -->
-      <div class="d-inline-block" v-if="displayAllNone">
+      <div
+        class="d-inline-block" v-if="displayAllNone"
+        :style="'line-height: 25px; bottom: ' + (centeredButtons ? -10 : 15) + 'px; position: relative;'"
+      >
         <div
           :class="'text-center mt-2 btn-xs eq-button-fancy ' + (parseInt(mask) >= 65535 ? 'eq-button-fancy-highlighted' : '')"
           @click="selectAll()"
@@ -39,7 +42,6 @@
 
 <script>
 import {DB_PLAYER_RACES} from "@/app/constants/eq-races-constants";
-import {App}             from "@/constants/app";
 import util              from "util";
 
 export default {
@@ -87,7 +89,6 @@ export default {
   data() {
     return {
       races: DB_PLAYER_RACES,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
       selectedRaces: {},
       currentMask: 0
     }

--- a/frontend/src/views/Components.vue
+++ b/frontend/src/views/Components.vue
@@ -25,7 +25,7 @@
               <div class="row">
 
 
-                <div class="col-6 text-center">
+                <div class="col-4 text-center">
                   <!-- Window and Progress Bars -->
                   <eq-window title="Progress Bars" style="height: 90%">
                     Endurance

--- a/frontend/src/views/Spells.vue
+++ b/frontend/src/views/Spells.vue
@@ -8,15 +8,15 @@
           <eq-window class="mt-5 text-center">
 
             <div class="row">
-              <div v-for="(icon, index) in dbClassIcons" class="mb-3 text-center">
+              <div v-for="(icon, index) in dbClassIcons" class="text-center">
                 <div class="text-center p-1 col-lg-12 col-sm-12">
                   {{ dbClassesShort[index] }}
                   <div class="text-center">
-                    <img
+                    <span
                       @click="selectClass(index)"
-                      :src="itemCdnUrl + 'item_' + icon + '.png'"
-                      :style="'width:auto;' + (isClassSelected(index) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border: 2px solid rgb(218 218 218 / 0%); border-radius: 7px;')"
-                      class="mt-1">
+                      :style="'width:40px;' + (isClassSelected(index) ? 'border-radius: 7px;' : 'border-radius: 7px;')"
+                      :class="'mt-1 hover-highlight-inner item-' + icon + ' ' + (isClassSelected(index) ? 'highlight-selected-inner' : '')"
+                    />
                   </div>
                 </div>
               </div>
@@ -35,7 +35,8 @@
                   placeholder="Name or ID"
                   autofocus=""
                   id="spell_name"
-                  value="">
+                  value=""
+                >
               </div>
 
               <div class="col-lg-2 col-sm-12 text-center">
@@ -45,7 +46,8 @@
                   id="spell_effect"
                   class="form-control"
                   v-model="selectedSpa"
-                  @change="triggerState()">
+                  @change="triggerState()"
+                >
 
                   <option value="-1">-- Select --</option>
                   <option v-for="(spellEffect, id) in dbSpellEffects" v-bind:value="id">
@@ -63,7 +65,8 @@
                   id="Class"
                   class="form-control"
                   v-model="selectedLevel"
-                  @change="selectClass(selectedClass)">
+                  @change="selectClass(selectedClass)"
+                >
                   <option value="0">-- Select --</option>
                   <option v-for="l in 105" v-bind:value="l">
                     {{ l }}
@@ -88,7 +91,8 @@
                   id="Class"
                   class="form-control"
                   v-model="listType"
-                  @change="triggerState()">
+                  @change="triggerState()"
+                >
                   <option value="table">Table</option>
                   <option value="card">Cards</option>
                 </select>
@@ -116,10 +120,12 @@
 
           <!-- card rendering -->
           <div class="row" style="justify-content: center" v-if="loaded && listType === 'card'">
-            <div v-for="(spell, index) in spells"
-                 class="col-lg-4 col-sm-9"
-                 :key="spell.id"
-                 style="display: inline-block; vertical-align: top">
+            <div
+              v-for="(spell, index) in spells"
+              class="col-lg-4 col-sm-9"
+              :key="spell.id"
+              style="display: inline-block; vertical-align: top"
+            >
               <eq-window style="margin-right: 10px; width: auto; height: 90%">
                 <eq-spell-preview :spell-data="spell"/>
               </eq-window>
@@ -144,7 +150,6 @@ import EqItemCardPreview from "@/components/eq-ui/EQItemCardPreview.vue";
 import * as util from "util";
 import EqSpellPreview from "@/components/eq-ui/EQSpellCardPreview.vue";
 import {DB_CLASSES_ICONS} from "@/app/constants/eq-class-icon-constants";
-import {App} from "@/constants/app";
 import {DB_CLASSES_SHORT, DB_PLAYER_CLASSES} from "@/app/constants/eq-classes-constants";
 import {DB_SPA} from "@/app/constants/eq-spell-constants";
 import EqSpellPreviewTable from "@/components/eq-ui/EQSpellPreviewTable.vue";
@@ -172,7 +177,6 @@ export default {
       dbClassesShort: DB_CLASSES_SHORT,
       dbClasses: DB_PLAYER_CLASSES,
       dbSpellEffects: DB_SPA,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
 
       // form values
       selectedClass: 0,
@@ -235,13 +239,13 @@ export default {
     },
 
     resetForm: function () {
-      this.selectedClass = 0;
-      this.spellName = "";
-      this.spellEffect = "";
-      this.selectedSpa = -1;
-      this.selectedLevel = 0;
+      this.selectedClass     = 0;
+      this.spellName         = "";
+      this.spellEffect       = "";
+      this.selectedSpa       = -1;
+      this.selectedLevel     = 0;
       this.selectedLevelType = 0;
-      this.spells = null;
+      this.spells            = null;
       this.updateQueryState()
     },
 
@@ -268,8 +272,8 @@ export default {
 
     selectClass: function (eqClass) {
       this.selectedClass = eqClass;
-      this.spellName = ""
-      this.selectedSpa = -1
+      this.spellName     = ""
+      this.selectedSpa   = -1
       this.updateQueryState();
       this.listSpells()
     },
@@ -290,10 +294,10 @@ export default {
     },
 
     listSpells: function () {
-      this.loaded = false;
+      this.loaded  = false;
       this.message = ""
 
-      const api = (new SpellsNewApi(SpireApiClient.getOpenApiConfig()))
+      const api   = (new SpellsNewApi(SpireApiClient.getOpenApiConfig()))
       let filters = [];
       let whereOr = [];
 
@@ -349,12 +353,12 @@ export default {
         wheresOrs.push(where)
       })
 
-      let request = {};
+      let request   = {};
       // this.message = "Refine search criteria to get more results...";
       request.limit = this.limit;
       if (this.selectedLevel && this.selectedLevel > 0) {
         request.limit = 1000
-        this.message = ""
+        this.message  = ""
       }
 
 
@@ -378,7 +382,7 @@ export default {
 
           // fetch spell ids that might be referenced by effects to bulk preload
           let spellsToPreload = [];
-          let itemsToPreload = [];
+          let itemsToPreload  = [];
           result.data.forEach((spell) => {
             for (let effectIndex = 1; effectIndex <= 12; effectIndex++) {
               const spellId = Spells.getSpellIdFromEffectIfExists(spell, effectIndex);

--- a/frontend/src/views/item-editor/components/ItemSpellEffectSelector.vue
+++ b/frontend/src/views/item-editor/components/ItemSpellEffectSelector.vue
@@ -1,24 +1,23 @@
 <template>
   <div>
-    <eq-window style="margin-top: 30px;">
+    <eq-window-simple style="margin-top: 20px;">
       <div
-        class="row text-center"
+        class="row text-center justify-content-center mb-3"
         style="margin: 0 auto;"
       >
         <div
           v-for="(icon, index) in dbClassIcons"
-          class="mb-3 text-center"
+          class="mb-3 text-center mr-4"
         >
           <div class="text-center col-lg-12 p-0 col-sm-12">
             {{ dbClassesShort[index] }}
             <div class="text-center">
-              <img
+              <div
+                style="display: block"
                 @click="selectClass(index)"
-                :src="itemCdnUrl + 'item_' + icon + '.png'"
-                :style="'width:auto; height: 35px; ' + (isClassSelected(index) ? 'border: 2px solid #dadada; border-radius: 7px;' : 'border: 2px solid rgb(218 218 218 / 0%); border-radius: 7px;')"
-                class="mt-1 p-0"
-                alt=""
-              >
+                :class="'mt-1 hover-highlight-inner item-' + icon + ' ' + (isClassSelected(index) ? 'highlight-selected-inner' : '')"
+              />
+
             </div>
           </div>
         </div>
@@ -102,26 +101,26 @@
         </div>
 
       </div>
+    </eq-window-simple>
 
-      <app-loader :is-loading="!loaded" padding="4"/>
+    <app-loader :is-loading="!loaded" padding="4"/>
 
+    <eq-window-simple
+      style="overflow-y: scroll; overflow-x: hidden; height: 60vh"
+      id="spell-effect-selector-view-port"
+      v-if="loaded && spells"
+    >
       <div v-if="message">
         {{ message }}
       </div>
 
-      <div
-        style="height: 75vh; overflow-y: scroll"
-        id="spell-effect-selector-view-port"
+      <eq-spell-preview-table-selector
+        :spells="spells"
+        @input="bubbleToParent($event)"
         v-if="loaded && spells"
-      >
-        <eq-spell-preview-table-selector
-          :spells="spells"
-          @input="bubbleToParent($event)"
-          v-if="loaded && spells"
-        />
-      </div>
+      />
 
-    </eq-window>
+    </eq-window-simple>
   </div>
 </template>
 
@@ -140,10 +139,12 @@ import EqSpellPreviewTable from "@/components/eq-ui/EQSpellPreviewTable.vue";
 import {Spells} from "@/app/spells";
 import {Items} from "@/app/items";
 import EqSpellPreviewTableSelector from "@/components/eq-ui/EQSpellPreviewTableSelector.vue";
+import EqWindowSimple from "@/components/eq-ui/EQWindowSimple.vue";
 
 export default {
   name: "SpellEffectSelector",
   components: {
+    EqWindowSimple,
     EqSpellPreviewTableSelector,
     EqSpellPreviewTable,
     EqSpellPreview,

--- a/frontend/src/views/items/Items.vue
+++ b/frontend/src/views/items/Items.vue
@@ -231,7 +231,6 @@ import {SpireApiClient} from "@/app/api/spire-api-client";
 import * as util from "util";
 import EqItemCardPreview from "@/components/eq-ui/EQItemCardPreview.vue";
 import {DB_CLASSES_ICONS} from "@/app/constants/eq-class-icon-constants";
-import {App} from "@/constants/app";
 import {DB_CLASSES_SHORT, DB_PLAYER_CLASSES} from "@/app/constants/eq-classes-constants";
 import {DB_SPA} from "@/app/constants/eq-spell-constants";
 import {Items} from "@/app/items";
@@ -269,7 +268,6 @@ export default {
       dbClassesShort: DB_CLASSES_SHORT,
       dbClasses: DB_PLAYER_CLASSES,
       dbItemEffects: DB_SPA,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
 
       // form values
       selectedClasses: 0,
@@ -653,8 +651,7 @@ export default {
       if (this.selectedClasses && parseInt(this.selectedClasses) > 0 && parseInt(this.selectedClasses) !== 65535) {
         if (this.selectOnlyClassEnabled) {
           filters.push(["classes", "__", this.selectedClasses]);
-        }
-        else {
+        } else {
           filters.push(["classes", "_bitwiseand_", this.selectedClasses]);
         }
 
@@ -719,7 +716,7 @@ export default {
       }
 
       if (filters.length === 0) {
-        this.items = null
+        this.items  = null
         this.loaded = true
         return;
       }

--- a/frontend/src/views/spell-editor/components/SpellClassSelector.vue
+++ b/frontend/src/views/spell-editor/components/SpellClassSelector.vue
@@ -5,15 +5,17 @@
         <div class="text-center">
           {{ gClass.short }}
           <div class="text-center">
-            <img
+            <span
               @click="selectClass(classId)"
-              :src="itemCdnUrl + 'item_' + gClass.icon + '.png'"
-              :style="'height: 45px; width:auto;' + selectedStyling(classId)"
-              class="mt-1 p-1 mb-2">
+              :style="(isClassSelected(classId) ? 'border-radius: 3px;' : 'border-radius: 3px; opacity: .6')"
+              :class="'item-' + gClass.icon + ' ' + (isClassSelected(classId) ? 'highlight-selected-inner' : '')"
+              class="mt-1 p-1 mb-2"
+            />
             <b-form-input
               v-model.number="spell['classes_' + classId]"
               @change="updateParent"
-              style="width: 45px; display: block; padding: 0; padding-left: 9px !important"/>
+              style="width: 45px; display: block; padding: 0; padding-left: 9px !important"
+            />
           </div>
         </div>
       </div>
@@ -22,7 +24,6 @@
 </template>
 
 <script>
-import {App}                   from "@/constants/app";
 import {DB_PLAYER_CLASSES_ALL} from "@/app/constants/eq-classes-constants";
 
 export default {
@@ -40,7 +41,6 @@ export default {
   data() {
     return {
       classes: DB_PLAYER_CLASSES_ALL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
     }
   },
   methods: {

--- a/frontend/src/views/spell-editor/components/SpellSpaPreviewPane.vue
+++ b/frontend/src/views/spell-editor/components/SpellSpaPreviewPane.vue
@@ -1,10 +1,10 @@
 <template>
   <div v-if="spa >= 0" class="ml-3">
 
-<!--    <div class="mb-4 mt-3" style="font-size: 14px; color: rgb(123, 113, 74);">-->
-<!--      Depending on the spell effect, the base, limit, max, formula values can mean different things. Below shows what-->
-<!--      values correspond to what for the Spell effect you have highlighted.-->
-<!--    </div>-->
+    <!--    <div class="mb-4 mt-3" style="font-size: 14px; color: rgb(123, 113, 74);">-->
+    <!--      Depending on the spell effect, the base, limit, max, formula values can mean different things. Below shows what-->
+    <!--      values correspond to what for the Spell effect you have highlighted.-->
+    <!--    </div>-->
 
     <h6 class="eq-header mt-3 mb-3">Spell Effect Details</h6>
 
@@ -69,7 +69,6 @@ export default {
       sideLoadedSpellData: {},
 
       spellCdnUrl: App.ASSET_SPELL_ICONS_BASE_URL,
-      itemCdnUrl: App.ASSET_ITEM_ICON_BASE_URL,
 
       componentId: "",
       reagents: [],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spire",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/Akkadius/spire.git"


### PR DESCRIPTION
## [1.6.6]

### UI Tweaks

All item icons in application now load from a spritesheet, removing the dependency on an additional set of 40MB of images being loaded into the binary