### PR TITLE
[2.2.1] [Update Logic] Only Update What's Changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.2.1]
+
+### [Update Logic] Only Update What's Changed
+
+Update logic for all saves has been rewritten to only update fields that have changed. This will also as a side effect resolve an issue where when values are set to zero, the object would not properly save.
+
 ## [2.1.1]
 
 ### [Items] Item Slot Ordering

--- a/boot/inject_mysql.go
+++ b/boot/inject_mysql.go
@@ -135,6 +135,7 @@ func provideEQEmuLocalDatabase(serverconfig *serverconfig.EQEmuServerConfig) (*g
 			SkipDefaultTransaction:                   true,
 			DisableForeignKeyConstraintWhenMigrating: true,
 			DisableAutomaticPing:                     false,
+			FullSaveAssociations:                     false,
 			Logger:                                   logger.Default.LogMode(logMode),
 		},
 	)
@@ -223,6 +224,7 @@ func provideSpireDatabase(serverconfig *serverconfig.EQEmuServerConfig) (*gorm.D
 			SkipDefaultTransaction:                   true,
 			DisableForeignKeyConstraintWhenMigrating: true,
 			DisableAutomaticPing:                     false,
+			FullSaveAssociations:                     false,
 			Logger:                                   logger.Default.LogMode(logMode),
 		},
 	)

--- a/containers/mariadb/Dockerfile
+++ b/containers/mariadb/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:latest
+FROM mariadb:10.5.4
 
 LABEL maintainer="Akkadius <akkadius1@gmail.com>"
 COPY my.cnf /etc/mysql/conf.d/my.cnf

--- a/internal/console/cmd/generate_race_model_maps.go
+++ b/internal/console/cmd/generate_race_model_maps.go
@@ -87,7 +87,7 @@ func (c *GenerateRaceModelMapsCommand) Handle(cmd *cobra.Command, _ []string) {
 	doc := soup.HTMLParse(contents)
 	for i := 0; i < 1000; i++ {
 
-		// add new race entry
+		// add New race entry
 		raceEntry := RaceEntry{}
 		raceEntry.RaceId = i
 
@@ -168,7 +168,7 @@ func (c *GenerateRaceModelMapsCommand) Handle(cmd *cobra.Command, _ []string) {
 			if len(li) > 0 {
 				for _, entry := range li {
 
-					// new source entry
+					// New source entry
 					source := Source{}
 
 					// text of li
@@ -227,7 +227,7 @@ func (c *GenerateRaceModelMapsCommand) Handle(cmd *cobra.Command, _ []string) {
 								modelCode = neutralModel
 							}
 
-							// new model
+							// New model
 							model := Model{
 								Code:           modelCode,
 								Gender:         gender,

--- a/internal/database/database_resolver.go
+++ b/internal/database/database_resolver.go
@@ -198,6 +198,7 @@ func (d *DatabaseResolver) ResolveUserEqemuConnection(model models.Modelable, us
 			SkipDefaultTransaction:                   true,
 			DisableForeignKeyConstraintWhenMigrating: true,
 			DisableAutomaticPing:                     false,
+			FullSaveAssociations:                     false,
 			Logger:                                   logger.Default.LogMode(logMode),
 		},
 	)

--- a/internal/database/model_compare.go
+++ b/internal/database/model_compare.go
@@ -1,0 +1,61 @@
+package database
+
+import (
+	"fmt"
+	"github.com/Akkadius/spire/internal/structs"
+	"reflect"
+	"strings"
+)
+
+type ModelDifference struct {
+	Field string
+	Old   interface{}
+	New   interface{}
+}
+
+// ResultDifference will return a map[string]interface{} based on differences between
+// two of the same models to be used in database updates
+func ResultDifference(v1 interface{}, v2 interface{}) map[string]interface{} {
+	results := make(map[string]interface{}, 0)
+	for _, d := range CompareModels(v1, v2) {
+		results[d.Field] = d.New
+	}
+
+	return results
+}
+
+// CompareModels will compare two of the same data models and determine
+// what fields are different
+// Example
+//
+// []database.ModelDifference{
+//  database.ModelDifference{
+//    Field: "type",
+//    Old:   2.000000,
+//    New:   1.000000,
+//  },
+//}
+func CompareModels(v1 interface{}, v2 interface{}) []ModelDifference {
+	var v1Model = structs.Map(v1)
+	var v2Model = structs.Map(v2)
+
+	var differences []ModelDifference
+	for v1Field := range v1Model {
+		for v2Field := range v2Model {
+			fType := fmt.Sprintf("%v", reflect.TypeOf(v1Model[v1Field]))
+
+			// struct mapper will export interfaces
+			isValidField := !strings.Contains(fType, "interface")
+
+			if v2Field == v1Field && isValidField && v1Model[v1Field] != v2Model[v1Field] {
+				differences = append(differences, ModelDifference{
+					Field: v1Field,
+					Old:   v1Model[v1Field],
+					New:   v2Model[v1Field],
+				})
+			}
+		}
+	}
+
+	return differences
+}

--- a/internal/generators/templates/crud_controller.tmpl
+++ b/internal/generators/templates/crud_controller.tmpl
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type {{.EntityName}}Controller struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func New{{.EntityName}}Controller(
 	logger *logrus.Logger,
 ) *{{.EntityName}}Controller {
 	return &{{.EntityName}}Controller{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *{{.EntityName}}Controller) update{{.EntityName}}(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.{{.EntityName}}{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/aa_ability_controller.go
+++ b/internal/http/crudcontrollers/aa_ability_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AaAbilityController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAaAbilityController(
 	logger *logrus.Logger,
 ) *AaAbilityController {
 	return &AaAbilityController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AaAbilityController) updateAaAbility(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AaAbility{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/aa_rank_controller.go
+++ b/internal/http/crudcontrollers/aa_rank_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AaRankController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAaRankController(
 	logger *logrus.Logger,
 ) *AaRankController {
 	return &AaRankController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AaRankController) updateAaRank(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AaRank{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/aa_rank_effect_controller.go
+++ b/internal/http/crudcontrollers/aa_rank_effect_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AaRankEffectController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAaRankEffectController(
 	logger *logrus.Logger,
 ) *AaRankEffectController {
 	return &AaRankEffectController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AaRankEffectController) updateAaRankEffect(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AaRankEffect{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/aa_rank_prereq_controller.go
+++ b/internal/http/crudcontrollers/aa_rank_prereq_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AaRankPrereqController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAaRankPrereqController(
 	logger *logrus.Logger,
 ) *AaRankPrereqController {
 	return &AaRankPrereqController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AaRankPrereqController) updateAaRankPrereq(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AaRankPrereq{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/account_controller.go
+++ b/internal/http/crudcontrollers/account_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AccountController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAccountController(
 	logger *logrus.Logger,
 ) *AccountController {
 	return &AccountController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AccountController) updateAccount(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Account{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/account_flag_controller.go
+++ b/internal/http/crudcontrollers/account_flag_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AccountFlagController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAccountFlagController(
 	logger *logrus.Logger,
 ) *AccountFlagController {
 	return &AccountFlagController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AccountFlagController) updateAccountFlag(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AccountFlag{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/account_ip_controller.go
+++ b/internal/http/crudcontrollers/account_ip_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AccountIpController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAccountIpController(
 	logger *logrus.Logger,
 ) *AccountIpController {
 	return &AccountIpController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AccountIpController) updateAccountIp(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AccountIp{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/account_reward_controller.go
+++ b/internal/http/crudcontrollers/account_reward_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AccountRewardController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAccountRewardController(
 	logger *logrus.Logger,
 ) *AccountRewardController {
 	return &AccountRewardController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AccountRewardController) updateAccountReward(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AccountReward{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_detail_controller.go
+++ b/internal/http/crudcontrollers/adventure_detail_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureDetailController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureDetailController(
 	logger *logrus.Logger,
 ) *AdventureDetailController {
 	return &AdventureDetailController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AdventureDetailController) updateAdventureDetail(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureDetail{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_member_controller.go
+++ b/internal/http/crudcontrollers/adventure_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureMemberController(
 	logger *logrus.Logger,
 ) *AdventureMemberController {
 	return &AdventureMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AdventureMemberController) updateAdventureMember(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_stat_controller.go
+++ b/internal/http/crudcontrollers/adventure_stat_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureStatController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureStatController(
 	logger *logrus.Logger,
 ) *AdventureStatController {
 	return &AdventureStatController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AdventureStatController) updateAdventureStat(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureStat{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_template_controller.go
+++ b/internal/http/crudcontrollers/adventure_template_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureTemplateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureTemplateController(
 	logger *logrus.Logger,
 ) *AdventureTemplateController {
 	return &AdventureTemplateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AdventureTemplateController) updateAdventureTemplate(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureTemplate{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_template_entry_controller.go
+++ b/internal/http/crudcontrollers/adventure_template_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureTemplateEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureTemplateEntryController(
 	logger *logrus.Logger,
 ) *AdventureTemplateEntryController {
 	return &AdventureTemplateEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *AdventureTemplateEntryController) updateAdventureTemplateEntry(c echo.C
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureTemplateEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/adventure_template_entry_flavor_controller.go
+++ b/internal/http/crudcontrollers/adventure_template_entry_flavor_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AdventureTemplateEntryFlavorController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAdventureTemplateEntryFlavorController(
 	logger *logrus.Logger,
 ) *AdventureTemplateEntryFlavorController {
 	return &AdventureTemplateEntryFlavorController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AdventureTemplateEntryFlavorController) updateAdventureTemplateEntryFla
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AdventureTemplateEntryFlavor{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/alternate_currency_controller.go
+++ b/internal/http/crudcontrollers/alternate_currency_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AlternateCurrencyController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAlternateCurrencyController(
 	logger *logrus.Logger,
 ) *AlternateCurrencyController {
 	return &AlternateCurrencyController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AlternateCurrencyController) updateAlternateCurrency(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.AlternateCurrency{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/aura_controller.go
+++ b/internal/http/crudcontrollers/aura_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type AuraController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewAuraController(
 	logger *logrus.Logger,
 ) *AuraController {
 	return &AuraController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *AuraController) updateAura(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Aura{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/base_datum_controller.go
+++ b/internal/http/crudcontrollers/base_datum_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BaseDatumController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBaseDatumController(
 	logger *logrus.Logger,
 ) *BaseDatumController {
 	return &BaseDatumController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *BaseDatumController) updateBaseDatum(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.BaseDatum{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/blocked_spell_controller.go
+++ b/internal/http/crudcontrollers/blocked_spell_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BlockedSpellController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBlockedSpellController(
 	logger *logrus.Logger,
 ) *BlockedSpellController {
 	return &BlockedSpellController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *BlockedSpellController) updateBlockedSpell(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.BlockedSpell{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/book_controller.go
+++ b/internal/http/crudcontrollers/book_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BookController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBookController(
 	logger *logrus.Logger,
 ) *BookController {
 	return &BookController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *BookController) updateBook(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Book{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/bot_datum_controller.go
+++ b/internal/http/crudcontrollers/bot_datum_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BotDatumController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBotDatumController(
 	logger *logrus.Logger,
 ) *BotDatumController {
 	return &BotDatumController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *BotDatumController) updateBotDatum(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.BotDatum{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/bug_controller.go
+++ b/internal/http/crudcontrollers/bug_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BugController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBugController(
 	logger *logrus.Logger,
 ) *BugController {
 	return &BugController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *BugController) updateBug(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Bug{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/bug_report_controller.go
+++ b/internal/http/crudcontrollers/bug_report_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BugReportController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBugReportController(
 	logger *logrus.Logger,
 ) *BugReportController {
 	return &BugReportController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *BugReportController) updateBugReport(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.BugReport{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/buyer_controller.go
+++ b/internal/http/crudcontrollers/buyer_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type BuyerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewBuyerController(
 	logger *logrus.Logger,
 ) *BuyerController {
 	return &BuyerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *BuyerController) updateBuyer(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Buyer{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/char_create_combination_controller.go
+++ b/internal/http/crudcontrollers/char_create_combination_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharCreateCombinationController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharCreateCombinationController(
 	logger *logrus.Logger,
 ) *CharCreateCombinationController {
 	return &CharCreateCombinationController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *CharCreateCombinationController) updateCharCreateCombination(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharCreateCombination{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/char_create_point_allocation_controller.go
+++ b/internal/http/crudcontrollers/char_create_point_allocation_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharCreatePointAllocationController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharCreatePointAllocationController(
 	logger *logrus.Logger,
 ) *CharCreatePointAllocationController {
 	return &CharCreatePointAllocationController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharCreatePointAllocationController) updateCharCreatePointAllocation(c 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharCreatePointAllocation{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/char_recipe_list_controller.go
+++ b/internal/http/crudcontrollers/char_recipe_list_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharRecipeListController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharRecipeListController(
 	logger *logrus.Logger,
 ) *CharRecipeListController {
 	return &CharRecipeListController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharRecipeListController) updateCharRecipeList(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharRecipeList{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_activity_controller.go
+++ b/internal/http/crudcontrollers/character_activity_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterActivityController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterActivityController(
 	logger *logrus.Logger,
 ) *CharacterActivityController {
 	return &CharacterActivityController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *CharacterActivityController) updateCharacterActivity(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterActivity{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_alt_currency_controller.go
+++ b/internal/http/crudcontrollers/character_alt_currency_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterAltCurrencyController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterAltCurrencyController(
 	logger *logrus.Logger,
 ) *CharacterAltCurrencyController {
 	return &CharacterAltCurrencyController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterAltCurrencyController) updateCharacterAltCurrency(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterAltCurrency{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_alternate_ability_controller.go
+++ b/internal/http/crudcontrollers/character_alternate_ability_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterAlternateAbilityController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterAlternateAbilityController(
 	logger *logrus.Logger,
 ) *CharacterAlternateAbilityController {
 	return &CharacterAlternateAbilityController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterAlternateAbilityController) updateCharacterAlternateAbility(c 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterAlternateAbility{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_aura_controller.go
+++ b/internal/http/crudcontrollers/character_aura_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterAuraController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterAuraController(
 	logger *logrus.Logger,
 ) *CharacterAuraController {
 	return &CharacterAuraController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterAuraController) updateCharacterAura(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterAura{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_bandolier_controller.go
+++ b/internal/http/crudcontrollers/character_bandolier_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterBandolierController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterBandolierController(
 	logger *logrus.Logger,
 ) *CharacterBandolierController {
 	return &CharacterBandolierController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *CharacterBandolierController) updateCharacterBandolier(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterBandolier{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_bind_controller.go
+++ b/internal/http/crudcontrollers/character_bind_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterBindController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterBindController(
 	logger *logrus.Logger,
 ) *CharacterBindController {
 	return &CharacterBindController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterBindController) updateCharacterBind(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterBind{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_buff_controller.go
+++ b/internal/http/crudcontrollers/character_buff_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterBuffController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterBuffController(
 	logger *logrus.Logger,
 ) *CharacterBuffController {
 	return &CharacterBuffController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterBuffController) updateCharacterBuff(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterBuff{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_corpse_controller.go
+++ b/internal/http/crudcontrollers/character_corpse_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterCorpseController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterCorpseController(
 	logger *logrus.Logger,
 ) *CharacterCorpseController {
 	return &CharacterCorpseController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterCorpseController) updateCharacterCorpse(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterCorpse{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_corpse_item_controller.go
+++ b/internal/http/crudcontrollers/character_corpse_item_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterCorpseItemController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterCorpseItemController(
 	logger *logrus.Logger,
 ) *CharacterCorpseItemController {
 	return &CharacterCorpseItemController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterCorpseItemController) updateCharacterCorpseItem(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterCorpseItem{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_currency_controller.go
+++ b/internal/http/crudcontrollers/character_currency_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterCurrencyController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterCurrencyController(
 	logger *logrus.Logger,
 ) *CharacterCurrencyController {
 	return &CharacterCurrencyController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterCurrencyController) updateCharacterCurrency(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterCurrency{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_datum_controller.go
+++ b/internal/http/crudcontrollers/character_datum_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterDatumController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterDatumController(
 	logger *logrus.Logger,
 ) *CharacterDatumController {
 	return &CharacterDatumController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterDatumController) updateCharacterDatum(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterDatum{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_discipline_controller.go
+++ b/internal/http/crudcontrollers/character_discipline_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterDisciplineController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterDisciplineController(
 	logger *logrus.Logger,
 ) *CharacterDisciplineController {
 	return &CharacterDisciplineController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterDisciplineController) updateCharacterDiscipline(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterDiscipline{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_enabledtask_controller.go
+++ b/internal/http/crudcontrollers/character_enabledtask_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterEnabledtaskController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterEnabledtaskController(
 	logger *logrus.Logger,
 ) *CharacterEnabledtaskController {
 	return &CharacterEnabledtaskController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterEnabledtaskController) updateCharacterEnabledtask(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterEnabledtask{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_exp_modifier_controller.go
+++ b/internal/http/crudcontrollers/character_exp_modifier_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterExpModifierController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterExpModifierController(
 	logger *logrus.Logger,
 ) *CharacterExpModifierController {
 	return &CharacterExpModifierController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterExpModifierController) updateCharacterExpModifier(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterExpModifier{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_expedition_lockout_controller.go
+++ b/internal/http/crudcontrollers/character_expedition_lockout_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterExpeditionLockoutController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterExpeditionLockoutController(
 	logger *logrus.Logger,
 ) *CharacterExpeditionLockoutController {
 	return &CharacterExpeditionLockoutController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterExpeditionLockoutController) updateCharacterExpeditionLockout(
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterExpeditionLockout{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_inspect_message_controller.go
+++ b/internal/http/crudcontrollers/character_inspect_message_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterInspectMessageController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterInspectMessageController(
 	logger *logrus.Logger,
 ) *CharacterInspectMessageController {
 	return &CharacterInspectMessageController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterInspectMessageController) updateCharacterInspectMessage(c echo
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterInspectMessage{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_instance_safereturn_controller.go
+++ b/internal/http/crudcontrollers/character_instance_safereturn_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterInstanceSafereturnController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterInstanceSafereturnController(
 	logger *logrus.Logger,
 ) *CharacterInstanceSafereturnController {
 	return &CharacterInstanceSafereturnController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterInstanceSafereturnController) updateCharacterInstanceSaferetur
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterInstanceSafereturn{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_item_recast_controller.go
+++ b/internal/http/crudcontrollers/character_item_recast_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterItemRecastController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterItemRecastController(
 	logger *logrus.Logger,
 ) *CharacterItemRecastController {
 	return &CharacterItemRecastController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterItemRecastController) updateCharacterItemRecast(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterItemRecast{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_language_controller.go
+++ b/internal/http/crudcontrollers/character_language_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterLanguageController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterLanguageController(
 	logger *logrus.Logger,
 ) *CharacterLanguageController {
 	return &CharacterLanguageController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterLanguageController) updateCharacterLanguage(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterLanguage{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_leadership_ability_controller.go
+++ b/internal/http/crudcontrollers/character_leadership_ability_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterLeadershipAbilityController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterLeadershipAbilityController(
 	logger *logrus.Logger,
 ) *CharacterLeadershipAbilityController {
 	return &CharacterLeadershipAbilityController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterLeadershipAbilityController) updateCharacterLeadershipAbility(
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterLeadershipAbility{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_material_controller.go
+++ b/internal/http/crudcontrollers/character_material_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterMaterialController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterMaterialController(
 	logger *logrus.Logger,
 ) *CharacterMaterialController {
 	return &CharacterMaterialController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterMaterialController) updateCharacterMaterial(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterMaterial{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_memmed_spell_controller.go
+++ b/internal/http/crudcontrollers/character_memmed_spell_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterMemmedSpellController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterMemmedSpellController(
 	logger *logrus.Logger,
 ) *CharacterMemmedSpellController {
 	return &CharacterMemmedSpellController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterMemmedSpellController) updateCharacterMemmedSpell(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterMemmedSpell{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_peqzone_flag_controller.go
+++ b/internal/http/crudcontrollers/character_peqzone_flag_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterPeqzoneFlagController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterPeqzoneFlagController(
 	logger *logrus.Logger,
 ) *CharacterPeqzoneFlagController {
 	return &CharacterPeqzoneFlagController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterPeqzoneFlagController) updateCharacterPeqzoneFlag(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterPeqzoneFlag{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_pet_buff_controller.go
+++ b/internal/http/crudcontrollers/character_pet_buff_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterPetBuffController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterPetBuffController(
 	logger *logrus.Logger,
 ) *CharacterPetBuffController {
 	return &CharacterPetBuffController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *CharacterPetBuffController) updateCharacterPetBuff(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterPetBuff{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_pet_info_controller.go
+++ b/internal/http/crudcontrollers/character_pet_info_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterPetInfoController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterPetInfoController(
 	logger *logrus.Logger,
 ) *CharacterPetInfoController {
 	return &CharacterPetInfoController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterPetInfoController) updateCharacterPetInfo(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterPetInfo{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_pet_inventory_controller.go
+++ b/internal/http/crudcontrollers/character_pet_inventory_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterPetInventoryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterPetInventoryController(
 	logger *logrus.Logger,
 ) *CharacterPetInventoryController {
 	return &CharacterPetInventoryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *CharacterPetInventoryController) updateCharacterPetInventory(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterPetInventory{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_potionbelt_controller.go
+++ b/internal/http/crudcontrollers/character_potionbelt_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterPotionbeltController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterPotionbeltController(
 	logger *logrus.Logger,
 ) *CharacterPotionbeltController {
 	return &CharacterPotionbeltController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterPotionbeltController) updateCharacterPotionbelt(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterPotionbelt{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_skill_controller.go
+++ b/internal/http/crudcontrollers/character_skill_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterSkillController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterSkillController(
 	logger *logrus.Logger,
 ) *CharacterSkillController {
 	return &CharacterSkillController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterSkillController) updateCharacterSkill(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterSkill{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_spell_controller.go
+++ b/internal/http/crudcontrollers/character_spell_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterSpellController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterSpellController(
 	logger *logrus.Logger,
 ) *CharacterSpellController {
 	return &CharacterSpellController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterSpellController) updateCharacterSpell(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterSpell{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_task_controller.go
+++ b/internal/http/crudcontrollers/character_task_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterTaskController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterTaskController(
 	logger *logrus.Logger,
 ) *CharacterTaskController {
 	return &CharacterTaskController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CharacterTaskController) updateCharacterTask(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterTask{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/character_task_timer_controller.go
+++ b/internal/http/crudcontrollers/character_task_timer_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CharacterTaskTimerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCharacterTaskTimerController(
 	logger *logrus.Logger,
 ) *CharacterTaskTimerController {
 	return &CharacterTaskTimerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CharacterTaskTimerController) updateCharacterTaskTimer(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CharacterTaskTimer{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/completed_shared_task_activity_state_controller.go
+++ b/internal/http/crudcontrollers/completed_shared_task_activity_state_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CompletedSharedTaskActivityStateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCompletedSharedTaskActivityStateController(
 	logger *logrus.Logger,
 ) *CompletedSharedTaskActivityStateController {
 	return &CompletedSharedTaskActivityStateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CompletedSharedTaskActivityStateController) updateCompletedSharedTaskAc
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CompletedSharedTaskActivityState{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/completed_shared_task_controller.go
+++ b/internal/http/crudcontrollers/completed_shared_task_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CompletedSharedTaskController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCompletedSharedTaskController(
 	logger *logrus.Logger,
 ) *CompletedSharedTaskController {
 	return &CompletedSharedTaskController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *CompletedSharedTaskController) updateCompletedSharedTask(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CompletedSharedTask{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/completed_shared_task_member_controller.go
+++ b/internal/http/crudcontrollers/completed_shared_task_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CompletedSharedTaskMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCompletedSharedTaskMemberController(
 	logger *logrus.Logger,
 ) *CompletedSharedTaskMemberController {
 	return &CompletedSharedTaskMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *CompletedSharedTaskMemberController) updateCompletedSharedTaskMember(c 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CompletedSharedTaskMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/completed_task_controller.go
+++ b/internal/http/crudcontrollers/completed_task_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type CompletedTaskController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewCompletedTaskController(
 	logger *logrus.Logger,
 ) *CompletedTaskController {
 	return &CompletedTaskController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *CompletedTaskController) updateCompletedTask(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.CompletedTask{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/content_flag_controller.go
+++ b/internal/http/crudcontrollers/content_flag_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ContentFlagController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewContentFlagController(
 	logger *logrus.Logger,
 ) *ContentFlagController {
 	return &ContentFlagController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ContentFlagController) updateContentFlag(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ContentFlag{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/damageshieldtype_controller.go
+++ b/internal/http/crudcontrollers/damageshieldtype_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DamageshieldtypeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDamageshieldtypeController(
 	logger *logrus.Logger,
 ) *DamageshieldtypeController {
 	return &DamageshieldtypeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DamageshieldtypeController) updateDamageshieldtype(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Damageshieldtype{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/data_bucket_controller.go
+++ b/internal/http/crudcontrollers/data_bucket_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DataBucketController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDataBucketController(
 	logger *logrus.Logger,
 ) *DataBucketController {
 	return &DataBucketController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DataBucketController) updateDataBucket(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DataBucket{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/db_str_controller.go
+++ b/internal/http/crudcontrollers/db_str_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DbStrController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDbStrController(
 	logger *logrus.Logger,
 ) *DbStrController {
 	return &DbStrController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *DbStrController) updateDbStr(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DbStr{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/discord_webhook_controller.go
+++ b/internal/http/crudcontrollers/discord_webhook_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DiscordWebhookController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDiscordWebhookController(
 	logger *logrus.Logger,
 ) *DiscordWebhookController {
 	return &DiscordWebhookController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DiscordWebhookController) updateDiscordWebhook(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DiscordWebhook{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/discovered_item_controller.go
+++ b/internal/http/crudcontrollers/discovered_item_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DiscoveredItemController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDiscoveredItemController(
 	logger *logrus.Logger,
 ) *DiscoveredItemController {
 	return &DiscoveredItemController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DiscoveredItemController) updateDiscoveredItem(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DiscoveredItem{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/door_controller.go
+++ b/internal/http/crudcontrollers/door_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DoorController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDoorController(
 	logger *logrus.Logger,
 ) *DoorController {
 	return &DoorController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DoorController) updateDoor(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Door{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/dynamic_zone_controller.go
+++ b/internal/http/crudcontrollers/dynamic_zone_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DynamicZoneController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDynamicZoneController(
 	logger *logrus.Logger,
 ) *DynamicZoneController {
 	return &DynamicZoneController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DynamicZoneController) updateDynamicZone(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DynamicZone{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/dynamic_zone_member_controller.go
+++ b/internal/http/crudcontrollers/dynamic_zone_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DynamicZoneMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDynamicZoneMemberController(
 	logger *logrus.Logger,
 ) *DynamicZoneMemberController {
 	return &DynamicZoneMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DynamicZoneMemberController) updateDynamicZoneMember(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DynamicZoneMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/dynamic_zone_template_controller.go
+++ b/internal/http/crudcontrollers/dynamic_zone_template_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type DynamicZoneTemplateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewDynamicZoneTemplateController(
 	logger *logrus.Logger,
 ) *DynamicZoneTemplateController {
 	return &DynamicZoneTemplateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *DynamicZoneTemplateController) updateDynamicZoneTemplate(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.DynamicZoneTemplate{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/eventlog_controller.go
+++ b/internal/http/crudcontrollers/eventlog_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type EventlogController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewEventlogController(
 	logger *logrus.Logger,
 ) *EventlogController {
 	return &EventlogController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *EventlogController) updateEventlog(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Eventlog{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/expedition_controller.go
+++ b/internal/http/crudcontrollers/expedition_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ExpeditionController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewExpeditionController(
 	logger *logrus.Logger,
 ) *ExpeditionController {
 	return &ExpeditionController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ExpeditionController) updateExpedition(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Expedition{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/expedition_lockout_controller.go
+++ b/internal/http/crudcontrollers/expedition_lockout_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ExpeditionLockoutController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewExpeditionLockoutController(
 	logger *logrus.Logger,
 ) *ExpeditionLockoutController {
 	return &ExpeditionLockoutController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ExpeditionLockoutController) updateExpeditionLockout(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ExpeditionLockout{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/faction_association_controller.go
+++ b/internal/http/crudcontrollers/faction_association_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FactionAssociationController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFactionAssociationController(
 	logger *logrus.Logger,
 ) *FactionAssociationController {
 	return &FactionAssociationController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *FactionAssociationController) updateFactionAssociation(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.FactionAssociation{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/faction_base_datum_controller.go
+++ b/internal/http/crudcontrollers/faction_base_datum_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FactionBaseDatumController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFactionBaseDatumController(
 	logger *logrus.Logger,
 ) *FactionBaseDatumController {
 	return &FactionBaseDatumController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *FactionBaseDatumController) updateFactionBaseDatum(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.FactionBaseDatum{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/faction_list_controller.go
+++ b/internal/http/crudcontrollers/faction_list_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FactionListController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFactionListController(
 	logger *logrus.Logger,
 ) *FactionListController {
 	return &FactionListController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *FactionListController) updateFactionList(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.FactionList{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/faction_list_mod_controller.go
+++ b/internal/http/crudcontrollers/faction_list_mod_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FactionListModController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFactionListModController(
 	logger *logrus.Logger,
 ) *FactionListModController {
 	return &FactionListModController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *FactionListModController) updateFactionListMod(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.FactionListMod{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/faction_value_controller.go
+++ b/internal/http/crudcontrollers/faction_value_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FactionValueController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFactionValueController(
 	logger *logrus.Logger,
 ) *FactionValueController {
 	return &FactionValueController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *FactionValueController) updateFactionValue(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.FactionValue{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/fishing_controller.go
+++ b/internal/http/crudcontrollers/fishing_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FishingController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFishingController(
 	logger *logrus.Logger,
 ) *FishingController {
 	return &FishingController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *FishingController) updateFishing(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Fishing{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/forage_controller.go
+++ b/internal/http/crudcontrollers/forage_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ForageController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewForageController(
 	logger *logrus.Logger,
 ) *ForageController {
 	return &ForageController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ForageController) updateForage(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Forage{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/friend_controller.go
+++ b/internal/http/crudcontrollers/friend_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type FriendController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewFriendController(
 	logger *logrus.Logger,
 ) *FriendController {
 	return &FriendController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *FriendController) updateFriend(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Friend{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/global_loot_controller.go
+++ b/internal/http/crudcontrollers/global_loot_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GlobalLootController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGlobalLootController(
 	logger *logrus.Logger,
 ) *GlobalLootController {
 	return &GlobalLootController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *GlobalLootController) updateGlobalLoot(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GlobalLoot{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/gm_ip_controller.go
+++ b/internal/http/crudcontrollers/gm_ip_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GmIpController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGmIpController(
 	logger *logrus.Logger,
 ) *GmIpController {
 	return &GmIpController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *GmIpController) updateGmIp(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GmIp{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/graveyard_controller.go
+++ b/internal/http/crudcontrollers/graveyard_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GraveyardController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGraveyardController(
 	logger *logrus.Logger,
 ) *GraveyardController {
 	return &GraveyardController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *GraveyardController) updateGraveyard(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Graveyard{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/grid_controller.go
+++ b/internal/http/crudcontrollers/grid_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GridController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGridController(
 	logger *logrus.Logger,
 ) *GridController {
 	return &GridController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *GridController) updateGrid(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Grid{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/grid_entry_controller.go
+++ b/internal/http/crudcontrollers/grid_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GridEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGridEntryController(
 	logger *logrus.Logger,
 ) *GridEntryController {
 	return &GridEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *GridEntryController) updateGridEntry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GridEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/ground_spawn_controller.go
+++ b/internal/http/crudcontrollers/ground_spawn_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GroundSpawnController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGroundSpawnController(
 	logger *logrus.Logger,
 ) *GroundSpawnController {
 	return &GroundSpawnController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *GroundSpawnController) updateGroundSpawn(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GroundSpawn{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/group_id_controller.go
+++ b/internal/http/crudcontrollers/group_id_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GroupIdController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGroupIdController(
 	logger *logrus.Logger,
 ) *GroupIdController {
 	return &GroupIdController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *GroupIdController) updateGroupId(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GroupId{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/guild_controller.go
+++ b/internal/http/crudcontrollers/guild_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GuildController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGuildController(
 	logger *logrus.Logger,
 ) *GuildController {
 	return &GuildController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *GuildController) updateGuild(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Guild{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/guild_member_controller.go
+++ b/internal/http/crudcontrollers/guild_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GuildMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGuildMemberController(
 	logger *logrus.Logger,
 ) *GuildMemberController {
 	return &GuildMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *GuildMemberController) updateGuildMember(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GuildMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/guild_rank_controller.go
+++ b/internal/http/crudcontrollers/guild_rank_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GuildRankController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGuildRankController(
 	logger *logrus.Logger,
 ) *GuildRankController {
 	return &GuildRankController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *GuildRankController) updateGuildRank(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GuildRank{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/guild_relation_controller.go
+++ b/internal/http/crudcontrollers/guild_relation_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type GuildRelationController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewGuildRelationController(
 	logger *logrus.Logger,
 ) *GuildRelationController {
 	return &GuildRelationController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *GuildRelationController) updateGuildRelation(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.GuildRelation{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/hacker_controller.go
+++ b/internal/http/crudcontrollers/hacker_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type HackerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewHackerController(
 	logger *logrus.Logger,
 ) *HackerController {
 	return &HackerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *HackerController) updateHacker(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Hacker{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/horse_controller.go
+++ b/internal/http/crudcontrollers/horse_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type HorseController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewHorseController(
 	logger *logrus.Logger,
 ) *HorseController {
 	return &HorseController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *HorseController) updateHorse(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Horse{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/instance_list_controller.go
+++ b/internal/http/crudcontrollers/instance_list_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type InstanceListController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewInstanceListController(
 	logger *logrus.Logger,
 ) *InstanceListController {
 	return &InstanceListController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *InstanceListController) updateInstanceList(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.InstanceList{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/instance_list_player_controller.go
+++ b/internal/http/crudcontrollers/instance_list_player_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type InstanceListPlayerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewInstanceListPlayerController(
 	logger *logrus.Logger,
 ) *InstanceListPlayerController {
 	return &InstanceListPlayerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *InstanceListPlayerController) updateInstanceListPlayer(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.InstanceListPlayer{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/inventory_controller.go
+++ b/internal/http/crudcontrollers/inventory_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type InventoryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewInventoryController(
 	logger *logrus.Logger,
 ) *InventoryController {
 	return &InventoryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *InventoryController) updateInventory(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Inventory{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/inventory_snapshot_controller.go
+++ b/internal/http/crudcontrollers/inventory_snapshot_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type InventorySnapshotController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewInventorySnapshotController(
 	logger *logrus.Logger,
 ) *InventorySnapshotController {
 	return &InventorySnapshotController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *InventorySnapshotController) updateInventorySnapshot(c echo.Context) er
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.InventorySnapshot{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/ip_exemption_controller.go
+++ b/internal/http/crudcontrollers/ip_exemption_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type IpExemptionController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewIpExemptionController(
 	logger *logrus.Logger,
 ) *IpExemptionController {
 	return &IpExemptionController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *IpExemptionController) updateIpExemption(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.IpExemption{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/item_controller.go
+++ b/internal/http/crudcontrollers/item_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ItemController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewItemController(
 	logger *logrus.Logger,
 ) *ItemController {
 	return &ItemController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ItemController) updateItem(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Item{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/item_tick_controller.go
+++ b/internal/http/crudcontrollers/item_tick_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ItemTickController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewItemTickController(
 	logger *logrus.Logger,
 ) *ItemTickController {
 	return &ItemTickController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ItemTickController) updateItemTick(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ItemTick{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/ldon_trap_entry_controller.go
+++ b/internal/http/crudcontrollers/ldon_trap_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LdonTrapEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLdonTrapEntryController(
 	logger *logrus.Logger,
 ) *LdonTrapEntryController {
 	return &LdonTrapEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *LdonTrapEntryController) updateLdonTrapEntry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LdonTrapEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/ldon_trap_template_controller.go
+++ b/internal/http/crudcontrollers/ldon_trap_template_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LdonTrapTemplateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLdonTrapTemplateController(
 	logger *logrus.Logger,
 ) *LdonTrapTemplateController {
 	return &LdonTrapTemplateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LdonTrapTemplateController) updateLdonTrapTemplate(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LdonTrapTemplate{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/level_exp_mod_controller.go
+++ b/internal/http/crudcontrollers/level_exp_mod_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LevelExpModController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLevelExpModController(
 	logger *logrus.Logger,
 ) *LevelExpModController {
 	return &LevelExpModController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LevelExpModController) updateLevelExpMod(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LevelExpMod{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/lfguild_controller.go
+++ b/internal/http/crudcontrollers/lfguild_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LfguildController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLfguildController(
 	logger *logrus.Logger,
 ) *LfguildController {
 	return &LfguildController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *LfguildController) updateLfguild(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Lfguild{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/login_account_controller.go
+++ b/internal/http/crudcontrollers/login_account_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoginAccountController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoginAccountController(
 	logger *logrus.Logger,
 ) *LoginAccountController {
 	return &LoginAccountController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoginAccountController) updateLoginAccount(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoginAccount{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/login_api_token_controller.go
+++ b/internal/http/crudcontrollers/login_api_token_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoginApiTokenController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoginApiTokenController(
 	logger *logrus.Logger,
 ) *LoginApiTokenController {
 	return &LoginApiTokenController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoginApiTokenController) updateLoginApiToken(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoginApiToken{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/login_server_admin_controller.go
+++ b/internal/http/crudcontrollers/login_server_admin_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoginServerAdminController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoginServerAdminController(
 	logger *logrus.Logger,
 ) *LoginServerAdminController {
 	return &LoginServerAdminController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoginServerAdminController) updateLoginServerAdmin(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoginServerAdmin{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/login_server_list_type_controller.go
+++ b/internal/http/crudcontrollers/login_server_list_type_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoginServerListTypeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoginServerListTypeController(
 	logger *logrus.Logger,
 ) *LoginServerListTypeController {
 	return &LoginServerListTypeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoginServerListTypeController) updateLoginServerListType(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoginServerListType{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/login_world_server_controller.go
+++ b/internal/http/crudcontrollers/login_world_server_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoginWorldServerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoginWorldServerController(
 	logger *logrus.Logger,
 ) *LoginWorldServerController {
 	return &LoginWorldServerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoginWorldServerController) updateLoginWorldServer(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoginWorldServer{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/logsys_category_controller.go
+++ b/internal/http/crudcontrollers/logsys_category_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LogsysCategoryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLogsysCategoryController(
 	logger *logrus.Logger,
 ) *LogsysCategoryController {
 	return &LogsysCategoryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LogsysCategoryController) updateLogsysCategory(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LogsysCategory{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/lootdrop_controller.go
+++ b/internal/http/crudcontrollers/lootdrop_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LootdropController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLootdropController(
 	logger *logrus.Logger,
 ) *LootdropController {
 	return &LootdropController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LootdropController) updateLootdrop(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Lootdrop{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/lootdrop_entry_controller.go
+++ b/internal/http/crudcontrollers/lootdrop_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LootdropEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLootdropEntryController(
 	logger *logrus.Logger,
 ) *LootdropEntryController {
 	return &LootdropEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *LootdropEntryController) updateLootdropEntry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LootdropEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/loottable_controller.go
+++ b/internal/http/crudcontrollers/loottable_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoottableController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoottableController(
 	logger *logrus.Logger,
 ) *LoottableController {
 	return &LoottableController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *LoottableController) updateLoottable(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Loottable{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/loottable_entry_controller.go
+++ b/internal/http/crudcontrollers/loottable_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type LoottableEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewLoottableEntryController(
 	logger *logrus.Logger,
 ) *LoottableEntryController {
 	return &LoottableEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *LoottableEntryController) updateLoottableEntry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.LoottableEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/mail_controller.go
+++ b/internal/http/crudcontrollers/mail_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type MailController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewMailController(
 	logger *logrus.Logger,
 ) *MailController {
 	return &MailController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *MailController) updateMail(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Mail{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/merchantlist_controller.go
+++ b/internal/http/crudcontrollers/merchantlist_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type MerchantlistController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewMerchantlistController(
 	logger *logrus.Logger,
 ) *MerchantlistController {
 	return &MerchantlistController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *MerchantlistController) updateMerchantlist(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Merchantlist{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/merchantlist_temp_controller.go
+++ b/internal/http/crudcontrollers/merchantlist_temp_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type MerchantlistTempController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewMerchantlistTempController(
 	logger *logrus.Logger,
 ) *MerchantlistTempController {
 	return &MerchantlistTempController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *MerchantlistTempController) updateMerchantlistTemp(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.MerchantlistTemp{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/name_filter_controller.go
+++ b/internal/http/crudcontrollers/name_filter_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NameFilterController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNameFilterController(
 	logger *logrus.Logger,
 ) *NameFilterController {
 	return &NameFilterController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NameFilterController) updateNameFilter(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NameFilter{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_emote_controller.go
+++ b/internal/http/crudcontrollers/npc_emote_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcEmoteController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcEmoteController(
 	logger *logrus.Logger,
 ) *NpcEmoteController {
 	return &NpcEmoteController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcEmoteController) updateNpcEmote(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcEmote{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_faction_controller.go
+++ b/internal/http/crudcontrollers/npc_faction_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcFactionController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcFactionController(
 	logger *logrus.Logger,
 ) *NpcFactionController {
 	return &NpcFactionController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcFactionController) updateNpcFaction(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcFaction{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_faction_entry_controller.go
+++ b/internal/http/crudcontrollers/npc_faction_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcFactionEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcFactionEntryController(
 	logger *logrus.Logger,
 ) *NpcFactionEntryController {
 	return &NpcFactionEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *NpcFactionEntryController) updateNpcFactionEntry(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcFactionEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_scale_global_base_controller.go
+++ b/internal/http/crudcontrollers/npc_scale_global_base_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcScaleGlobalBaseController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcScaleGlobalBaseController(
 	logger *logrus.Logger,
 ) *NpcScaleGlobalBaseController {
 	return &NpcScaleGlobalBaseController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *NpcScaleGlobalBaseController) updateNpcScaleGlobalBase(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcScaleGlobalBase{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_spell_controller.go
+++ b/internal/http/crudcontrollers/npc_spell_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcSpellController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcSpellController(
 	logger *logrus.Logger,
 ) *NpcSpellController {
 	return &NpcSpellController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcSpellController) updateNpcSpell(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcSpell{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_spells_effect_controller.go
+++ b/internal/http/crudcontrollers/npc_spells_effect_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcSpellsEffectController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcSpellsEffectController(
 	logger *logrus.Logger,
 ) *NpcSpellsEffectController {
 	return &NpcSpellsEffectController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcSpellsEffectController) updateNpcSpellsEffect(c echo.Context) error 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcSpellsEffect{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_spells_effects_entry_controller.go
+++ b/internal/http/crudcontrollers/npc_spells_effects_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcSpellsEffectsEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcSpellsEffectsEntryController(
 	logger *logrus.Logger,
 ) *NpcSpellsEffectsEntryController {
 	return &NpcSpellsEffectsEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcSpellsEffectsEntryController) updateNpcSpellsEffectsEntry(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcSpellsEffectsEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_spells_entry_controller.go
+++ b/internal/http/crudcontrollers/npc_spells_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcSpellsEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcSpellsEntryController(
 	logger *logrus.Logger,
 ) *NpcSpellsEntryController {
 	return &NpcSpellsEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcSpellsEntryController) updateNpcSpellsEntry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcSpellsEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_type_controller.go
+++ b/internal/http/crudcontrollers/npc_type_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcTypeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcTypeController(
 	logger *logrus.Logger,
 ) *NpcTypeController {
 	return &NpcTypeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcTypeController) updateNpcType(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcType{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/npc_types_tint_controller.go
+++ b/internal/http/crudcontrollers/npc_types_tint_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type NpcTypesTintController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewNpcTypesTintController(
 	logger *logrus.Logger,
 ) *NpcTypesTintController {
 	return &NpcTypesTintController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *NpcTypesTintController) updateNpcTypesTint(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.NpcTypesTint{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/object_content_controller.go
+++ b/internal/http/crudcontrollers/object_content_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ObjectContentController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewObjectContentController(
 	logger *logrus.Logger,
 ) *ObjectContentController {
 	return &ObjectContentController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *ObjectContentController) updateObjectContent(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ObjectContent{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/object_controller.go
+++ b/internal/http/crudcontrollers/object_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ObjectController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewObjectController(
 	logger *logrus.Logger,
 ) *ObjectController {
 	return &ObjectController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ObjectController) updateObject(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Object{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/perl_event_export_setting_controller.go
+++ b/internal/http/crudcontrollers/perl_event_export_setting_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PerlEventExportSettingController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPerlEventExportSettingController(
 	logger *logrus.Logger,
 ) *PerlEventExportSettingController {
 	return &PerlEventExportSettingController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PerlEventExportSettingController) updatePerlEventExportSetting(c echo.C
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.PerlEventExportSetting{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/pet_controller.go
+++ b/internal/http/crudcontrollers/pet_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PetController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPetController(
 	logger *logrus.Logger,
 ) *PetController {
 	return &PetController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PetController) updatePet(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Pet{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/petition_controller.go
+++ b/internal/http/crudcontrollers/petition_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PetitionController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPetitionController(
 	logger *logrus.Logger,
 ) *PetitionController {
 	return &PetitionController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PetitionController) updatePetition(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Petition{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/pets_beastlord_datum_controller.go
+++ b/internal/http/crudcontrollers/pets_beastlord_datum_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PetsBeastlordDatumController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPetsBeastlordDatumController(
 	logger *logrus.Logger,
 ) *PetsBeastlordDatumController {
 	return &PetsBeastlordDatumController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PetsBeastlordDatumController) updatePetsBeastlordDatum(c echo.Context) 
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.PetsBeastlordDatum{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/pets_equipmentset_controller.go
+++ b/internal/http/crudcontrollers/pets_equipmentset_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PetsEquipmentsetController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPetsEquipmentsetController(
 	logger *logrus.Logger,
 ) *PetsEquipmentsetController {
 	return &PetsEquipmentsetController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PetsEquipmentsetController) updatePetsEquipmentset(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.PetsEquipmentset{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/pets_equipmentset_entry_controller.go
+++ b/internal/http/crudcontrollers/pets_equipmentset_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PetsEquipmentsetEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPetsEquipmentsetEntryController(
 	logger *logrus.Logger,
 ) *PetsEquipmentsetEntryController {
 	return &PetsEquipmentsetEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *PetsEquipmentsetEntryController) updatePetsEquipmentsetEntry(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.PetsEquipmentsetEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/player_titleset_controller.go
+++ b/internal/http/crudcontrollers/player_titleset_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type PlayerTitlesetController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewPlayerTitlesetController(
 	logger *logrus.Logger,
 ) *PlayerTitlesetController {
 	return &PlayerTitlesetController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *PlayerTitlesetController) updatePlayerTitleset(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.PlayerTitleset{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/quest_global_controller.go
+++ b/internal/http/crudcontrollers/quest_global_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type QuestGlobalController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewQuestGlobalController(
 	logger *logrus.Logger,
 ) *QuestGlobalController {
 	return &QuestGlobalController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *QuestGlobalController) updateQuestGlobal(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.QuestGlobal{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/raid_detail_controller.go
+++ b/internal/http/crudcontrollers/raid_detail_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type RaidDetailController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewRaidDetailController(
 	logger *logrus.Logger,
 ) *RaidDetailController {
 	return &RaidDetailController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *RaidDetailController) updateRaidDetail(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.RaidDetail{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/raid_member_controller.go
+++ b/internal/http/crudcontrollers/raid_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type RaidMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewRaidMemberController(
 	logger *logrus.Logger,
 ) *RaidMemberController {
 	return &RaidMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *RaidMemberController) updateRaidMember(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.RaidMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/report_controller.go
+++ b/internal/http/crudcontrollers/report_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ReportController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewReportController(
 	logger *logrus.Logger,
 ) *ReportController {
 	return &ReportController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ReportController) updateReport(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Report{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/respawn_time_controller.go
+++ b/internal/http/crudcontrollers/respawn_time_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type RespawnTimeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewRespawnTimeController(
 	logger *logrus.Logger,
 ) *RespawnTimeController {
 	return &RespawnTimeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *RespawnTimeController) updateRespawnTime(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.RespawnTime{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/rule_set_controller.go
+++ b/internal/http/crudcontrollers/rule_set_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type RuleSetController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewRuleSetController(
 	logger *logrus.Logger,
 ) *RuleSetController {
 	return &RuleSetController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *RuleSetController) updateRuleSet(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.RuleSet{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/rule_value_controller.go
+++ b/internal/http/crudcontrollers/rule_value_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type RuleValueController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewRuleValueController(
 	logger *logrus.Logger,
 ) *RuleValueController {
 	return &RuleValueController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *RuleValueController) updateRuleValue(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.RuleValue{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/saylink_controller.go
+++ b/internal/http/crudcontrollers/saylink_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SaylinkController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSaylinkController(
 	logger *logrus.Logger,
 ) *SaylinkController {
 	return &SaylinkController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SaylinkController) updateSaylink(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Saylink{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/server_scheduled_event_controller.go
+++ b/internal/http/crudcontrollers/server_scheduled_event_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ServerScheduledEventController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewServerScheduledEventController(
 	logger *logrus.Logger,
 ) *ServerScheduledEventController {
 	return &ServerScheduledEventController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ServerScheduledEventController) updateServerScheduledEvent(c echo.Conte
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ServerScheduledEvent{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/shared_task_activity_state_controller.go
+++ b/internal/http/crudcontrollers/shared_task_activity_state_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SharedTaskActivityStateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSharedTaskActivityStateController(
 	logger *logrus.Logger,
 ) *SharedTaskActivityStateController {
 	return &SharedTaskActivityStateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *SharedTaskActivityStateController) updateSharedTaskActivityState(c echo
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SharedTaskActivityState{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/shared_task_controller.go
+++ b/internal/http/crudcontrollers/shared_task_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SharedTaskController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSharedTaskController(
 	logger *logrus.Logger,
 ) *SharedTaskController {
 	return &SharedTaskController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SharedTaskController) updateSharedTask(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SharedTask{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/shared_task_dynamic_zone_controller.go
+++ b/internal/http/crudcontrollers/shared_task_dynamic_zone_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SharedTaskDynamicZoneController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSharedTaskDynamicZoneController(
 	logger *logrus.Logger,
 ) *SharedTaskDynamicZoneController {
 	return &SharedTaskDynamicZoneController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *SharedTaskDynamicZoneController) updateSharedTaskDynamicZone(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SharedTaskDynamicZone{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/shared_task_member_controller.go
+++ b/internal/http/crudcontrollers/shared_task_member_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SharedTaskMemberController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSharedTaskMemberController(
 	logger *logrus.Logger,
 ) *SharedTaskMemberController {
 	return &SharedTaskMemberController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *SharedTaskMemberController) updateSharedTaskMember(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SharedTaskMember{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/skill_cap_controller.go
+++ b/internal/http/crudcontrollers/skill_cap_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SkillCapController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSkillCapController(
 	logger *logrus.Logger,
 ) *SkillCapController {
 	return &SkillCapController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *SkillCapController) updateSkillCap(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SkillCap{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawn_2_controller.go
+++ b/internal/http/crudcontrollers/spawn_2_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type Spawn2Controller struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawn2Controller(
 	logger *logrus.Logger,
 ) *Spawn2Controller {
 	return &Spawn2Controller{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *Spawn2Controller) updateSpawn2(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Spawn2{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawn_condition_controller.go
+++ b/internal/http/crudcontrollers/spawn_condition_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpawnConditionController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawnConditionController(
 	logger *logrus.Logger,
 ) *SpawnConditionController {
 	return &SpawnConditionController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *SpawnConditionController) updateSpawnCondition(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpawnCondition{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawn_condition_value_controller.go
+++ b/internal/http/crudcontrollers/spawn_condition_value_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpawnConditionValueController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawnConditionValueController(
 	logger *logrus.Logger,
 ) *SpawnConditionValueController {
 	return &SpawnConditionValueController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -202,7 +203,8 @@ func (e *SpawnConditionValueController) updateSpawnConditionValue(c echo.Context
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpawnConditionValue{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawn_event_controller.go
+++ b/internal/http/crudcontrollers/spawn_event_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpawnEventController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawnEventController(
 	logger *logrus.Logger,
 ) *SpawnEventController {
 	return &SpawnEventController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SpawnEventController) updateSpawnEvent(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpawnEvent{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawnentry_controller.go
+++ b/internal/http/crudcontrollers/spawnentry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpawnentryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawnentryController(
 	logger *logrus.Logger,
 ) *SpawnentryController {
 	return &SpawnentryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *SpawnentryController) updateSpawnentry(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Spawnentry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spawngroup_controller.go
+++ b/internal/http/crudcontrollers/spawngroup_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpawngroupController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpawngroupController(
 	logger *logrus.Logger,
 ) *SpawngroupController {
 	return &SpawngroupController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SpawngroupController) updateSpawngroup(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Spawngroup{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spell_bucket_controller.go
+++ b/internal/http/crudcontrollers/spell_bucket_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpellBucketController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpellBucketController(
 	logger *logrus.Logger,
 ) *SpellBucketController {
 	return &SpellBucketController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SpellBucketController) updateSpellBucket(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpellBucket{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spell_global_controller.go
+++ b/internal/http/crudcontrollers/spell_global_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpellGlobalController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpellGlobalController(
 	logger *logrus.Logger,
 ) *SpellGlobalController {
 	return &SpellGlobalController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SpellGlobalController) updateSpellGlobal(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpellGlobal{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/spells_new_controller.go
+++ b/internal/http/crudcontrollers/spells_new_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type SpellsNewController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewSpellsNewController(
 	logger *logrus.Logger,
 ) *SpellsNewController {
 	return &SpellsNewController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *SpellsNewController) updateSpellsNew(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.SpellsNew{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/start_zone_controller.go
+++ b/internal/http/crudcontrollers/start_zone_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type StartZoneController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewStartZoneController(
 	logger *logrus.Logger,
 ) *StartZoneController {
 	return &StartZoneController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -224,7 +225,8 @@ func (e *StartZoneController) updateStartZone(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.StartZone{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/starting_item_controller.go
+++ b/internal/http/crudcontrollers/starting_item_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type StartingItemController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewStartingItemController(
 	logger *logrus.Logger,
 ) *StartingItemController {
 	return &StartingItemController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *StartingItemController) updateStartingItem(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.StartingItem{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/task_activity_controller.go
+++ b/internal/http/crudcontrollers/task_activity_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TaskActivityController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTaskActivityController(
 	logger *logrus.Logger,
 ) *TaskActivityController {
 	return &TaskActivityController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TaskActivityController) updateTaskActivity(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.TaskActivity{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/task_controller.go
+++ b/internal/http/crudcontrollers/task_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TaskController struct {
-	db	 *database.DatabaseResolver
+	db     *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTaskController(
 	logger *logrus.Logger,
 ) *TaskController {
 	return &TaskController{
-		db:	 db,
+		db:     db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *TaskController) updateTask(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Task{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/task_controller.go
+++ b/internal/http/crudcontrollers/task_controller.go
@@ -13,7 +13,7 @@ import (
 )
 
 type TaskController struct {
-	db     *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -22,7 +22,7 @@ func NewTaskController(
 	logger *logrus.Logger,
 ) *TaskController {
 	return &TaskController{
-		db:     db,
+		db:	    db,
 		logger: logger,
 	}
 }

--- a/internal/http/crudcontrollers/taskset_controller.go
+++ b/internal/http/crudcontrollers/taskset_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TasksetController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTasksetController(
 	logger *logrus.Logger,
 ) *TasksetController {
 	return &TasksetController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TasksetController) updateTaskset(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Taskset{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/timer_controller.go
+++ b/internal/http/crudcontrollers/timer_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TimerController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTimerController(
 	logger *logrus.Logger,
 ) *TimerController {
 	return &TimerController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TimerController) updateTimer(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Timer{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/title_controller.go
+++ b/internal/http/crudcontrollers/title_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TitleController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTitleController(
 	logger *logrus.Logger,
 ) *TitleController {
 	return &TitleController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *TitleController) updateTitle(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Title{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/trader_controller.go
+++ b/internal/http/crudcontrollers/trader_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TraderController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTraderController(
 	logger *logrus.Logger,
 ) *TraderController {
 	return &TraderController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TraderController) updateTrader(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Trader{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/tradeskill_recipe_controller.go
+++ b/internal/http/crudcontrollers/tradeskill_recipe_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TradeskillRecipeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTradeskillRecipeController(
 	logger *logrus.Logger,
 ) *TradeskillRecipeController {
 	return &TradeskillRecipeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *TradeskillRecipeController) updateTradeskillRecipe(c echo.Context) erro
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.TradeskillRecipe{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/tradeskill_recipe_entry_controller.go
+++ b/internal/http/crudcontrollers/tradeskill_recipe_entry_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TradeskillRecipeEntryController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTradeskillRecipeEntryController(
 	logger *logrus.Logger,
 ) *TradeskillRecipeEntryController {
 	return &TradeskillRecipeEntryController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *TradeskillRecipeEntryController) updateTradeskillRecipeEntry(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.TradeskillRecipeEntry{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/trap_controller.go
+++ b/internal/http/crudcontrollers/trap_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TrapController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTrapController(
 	logger *logrus.Logger,
 ) *TrapController {
 	return &TrapController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *TrapController) updateTrap(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Trap{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/tribute_controller.go
+++ b/internal/http/crudcontrollers/tribute_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TributeController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTributeController(
 	logger *logrus.Logger,
 ) *TributeController {
 	return &TributeController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TributeController) updateTribute(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Tribute{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/tribute_level_controller.go
+++ b/internal/http/crudcontrollers/tribute_level_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type TributeLevelController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewTributeLevelController(
 	logger *logrus.Logger,
 ) *TributeLevelController {
 	return &TributeLevelController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *TributeLevelController) updateTributeLevel(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.TributeLevel{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/veteran_reward_template_controller.go
+++ b/internal/http/crudcontrollers/veteran_reward_template_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type VeteranRewardTemplateController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewVeteranRewardTemplateController(
 	logger *logrus.Logger,
 ) *VeteranRewardTemplateController {
 	return &VeteranRewardTemplateController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *VeteranRewardTemplateController) updateVeteranRewardTemplate(c echo.Con
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.VeteranRewardTemplate{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/zone_controller.go
+++ b/internal/http/crudcontrollers/zone_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ZoneController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewZoneController(
 	logger *logrus.Logger,
 ) *ZoneController {
 	return &ZoneController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ZoneController) updateZone(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.Zone{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/zone_flag_controller.go
+++ b/internal/http/crudcontrollers/zone_flag_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ZoneFlagController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewZoneFlagController(
 	logger *logrus.Logger,
 ) *ZoneFlagController {
 	return &ZoneFlagController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -180,7 +181,8 @@ func (e *ZoneFlagController) updateZoneFlag(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ZoneFlag{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/http/crudcontrollers/zone_point_controller.go
+++ b/internal/http/crudcontrollers/zone_point_controller.go
@@ -7,12 +7,13 @@ import (
 	"github.com/Akkadius/spire/internal/models"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 	"net/http"
 	"strconv"
 )
 
 type ZonePointController struct {
-	db	 *database.DatabaseResolver
+	db	   *database.DatabaseResolver
 	logger *logrus.Logger
 }
 
@@ -21,7 +22,7 @@ func NewZonePointController(
 	logger *logrus.Logger,
 ) *ZonePointController {
 	return &ZonePointController{
-		db:	 db,
+		db:	    db,
 		logger: logger,
 	}
 }
@@ -158,7 +159,8 @@ func (e *ZonePointController) updateZonePoint(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Cannot find entity [%s]", err.Error())})
 	}
 
-	err = e.db.QueryContext(models.ZonePoint{}, c).Updates(&request).Error
+	// save top-level using only changes
+	err = query.Session(&gorm.Session{FullSaveAssociations: false}).Updates(database.ResultDifference(result, request)).Error
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": fmt.Sprintf("Error updating entity [%v]", err.Error())})
 	}

--- a/internal/permissions/resources.go
+++ b/internal/permissions/resources.go
@@ -9,6 +9,8 @@ import (
 	"github.com/k0kubun/pp/v3"
 	"github.com/labstack/echo/v4"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	"os"
 	"sort"
 	"strings"
@@ -134,7 +136,7 @@ func (c *ResourceList) Get() []Resource {
 				// title case
 				title := resource
 				title = strings.ReplaceAll(title, "_", " ")
-				title = strings.Title(title)
+				title = cases.Title(language.English).String(title)
 
 				// count routes per resource
 				resourceRouteCount[title]++

--- a/internal/structs/.gitignore
+++ b/internal/structs/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/internal/structs/.travis.yml
+++ b/internal/structs/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go: 
+ - 1.7.x
+ - 1.8.x
+ - 1.9.x
+ - tip
+sudo: false
+before_install:
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- if ! go get github.com/golang/tools/cmd/cover; then go get golang.org/x/tools/cmd/cover; fi
+script:
+- $HOME/gopath/bin/goveralls -service=travis-ci

--- a/internal/structs/LICENSE
+++ b/internal/structs/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Fatih Arslan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/internal/structs/README.md
+++ b/internal/structs/README.md
@@ -1,0 +1,170 @@
+# Archived project. No maintenance. 
+
+This project is not maintained anymore and is archived. Feel free to fork and
+make your own changes if needed. For more detail read my blog post: [Taking an indefinite sabbatical from my projects](https://arslan.io/2018/10/09/taking-an-indefinite-sabbatical-from-my-projects/)
+
+Thanks to everyone for their valuable feedback and contributions.
+
+# Structs [![GoDoc](http://img.shields.io/badge/go-documentation-blue.svg?style=flat-square)](http://godoc.org/github.com/fatih/structs) [![Build Status](http://img.shields.io/travis/fatih/structs.svg?style=flat-square)](https://travis-ci.org/fatih/structs) [![Coverage Status](http://img.shields.io/coveralls/fatih/structs.svg?style=flat-square)](https://coveralls.io/r/fatih/structs)
+
+Structs contains various utilities to work with Go (Golang) structs. It was
+initially used by me to convert a struct into a `map[string]interface{}`. With
+time I've added other utilities for structs.  It's basically a high level
+package based on primitives from the reflect package. Feel free to add new
+functions or improve the existing code.
+
+## Install
+
+```bash
+go get github.com/fatih/structs
+```
+
+## Usage and Examples
+
+Just like the standard lib `strings`, `bytes` and co packages, `structs` has
+many global functions to manipulate or organize your struct data. Lets define
+and declare a struct:
+
+```go
+type Server struct {
+	Name        string `json:"name,omitempty"`
+	ID          int
+	Enabled     bool
+	users       []string // not exported
+	http.Server          // embedded
+}
+
+server := &Server{
+	Name:    "gopher",
+	ID:      123456,
+	Enabled: true,
+}
+```
+
+```go
+// Convert a struct to a map[string]interface{}
+// => {"Name":"gopher", "ID":123456, "Enabled":true}
+m := structs.Map(server)
+
+// Convert the values of a struct to a []interface{}
+// => ["gopher", 123456, true]
+v := structs.Values(server)
+
+// Convert the names of a struct to a []string
+// (see "Names methods" for more info about fields)
+n := structs.Names(server)
+
+// Convert the values of a struct to a []*Field
+// (see "Field methods" for more info about fields)
+f := structs.Fields(server)
+
+// Return the struct name => "Server"
+n := structs.Name(server)
+
+// Check if any field of a struct is initialized or not.
+h := structs.HasZero(server)
+
+// Check if all fields of a struct is initialized or not.
+z := structs.IsZero(server)
+
+// Check if server is a struct or a pointer to struct
+i := structs.IsStruct(server)
+```
+
+### Struct methods
+
+The structs functions can be also used as independent methods by creating a new
+`*structs.Struct`. This is handy if you want to have more control over the
+structs (such as retrieving a single Field).
+
+```go
+// Create a new struct type:
+s := structs.New(server)
+
+m := s.Map()              // Get a map[string]interface{}
+v := s.Values()           // Get a []interface{}
+f := s.Fields()           // Get a []*Field
+n := s.Names()            // Get a []string
+f := s.Field(name)        // Get a *Field based on the given field name
+f, ok := s.FieldOk(name)  // Get a *Field based on the given field name
+n := s.Name()             // Get the struct name
+h := s.HasZero()          // Check if any field is uninitialized
+z := s.IsZero()           // Check if all fields are uninitialized
+```
+
+### Field methods
+
+We can easily examine a single Field for more detail. Below you can see how we
+get and interact with various field methods:
+
+
+```go
+s := structs.New(server)
+
+// Get the Field struct for the "Name" field
+name := s.Field("Name")
+
+// Get the underlying value,  value => "gopher"
+value := name.Value().(string)
+
+// Set the field's value
+name.Set("another gopher")
+
+// Get the field's kind, kind =>  "string"
+name.Kind()
+
+// Check if the field is exported or not
+if name.IsExported() {
+	fmt.Println("Name field is exported")
+}
+
+// Check if the value is a zero value, such as "" for string, 0 for int
+if !name.IsZero() {
+	fmt.Println("Name is initialized")
+}
+
+// Check if the field is an anonymous (embedded) field
+if !name.IsEmbedded() {
+	fmt.Println("Name is not an embedded field")
+}
+
+// Get the Field's tag value for tag name "json", tag value => "name,omitempty"
+tagValue := name.Tag("json")
+```
+
+Nested structs are supported too:
+
+```go
+addrField := s.Field("Server").Field("Addr")
+
+// Get the value for addr
+a := addrField.Value().(string)
+
+// Or get all fields
+httpServer := s.Field("Server").Fields()
+```
+
+We can also get a slice of Fields from the Struct type to iterate over all
+fields. This is handy if you wish to examine all fields:
+
+```go
+s := structs.New(server)
+
+for _, f := range s.Fields() {
+	fmt.Printf("field name: %+v\n", f.Name())
+
+	if f.IsExported() {
+		fmt.Printf("value   : %+v\n", f.Value())
+		fmt.Printf("is zero : %+v\n", f.IsZero())
+	}
+}
+```
+
+## Credits
+
+ * [Fatih Arslan](https://github.com/fatih)
+ * [Cihangir Savas](https://github.com/cihangir)
+
+## License
+
+The MIT License (MIT) - see LICENSE.md for more details

--- a/internal/structs/field.go
+++ b/internal/structs/field.go
@@ -1,0 +1,141 @@
+package structs
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+var (
+	errNotExported = errors.New("field is not exported")
+	errNotSettable = errors.New("field is not settable")
+)
+
+// Field represents a single struct field that encapsulates high level
+// functions around the field.
+type Field struct {
+	value      reflect.Value
+	field      reflect.StructField
+	defaultTag string
+}
+
+// Tag returns the value associated with key in the tag string. If there is no
+// such key in the tag, Tag returns the empty string.
+func (f *Field) Tag(key string) string {
+	return f.field.Tag.Get(key)
+}
+
+// Value returns the underlying value of the field. It panics if the field
+// is not exported.
+func (f *Field) Value() interface{} {
+	return f.value.Interface()
+}
+
+// IsEmbedded returns true if the given field is an anonymous field (embedded)
+func (f *Field) IsEmbedded() bool {
+	return f.field.Anonymous
+}
+
+// IsExported returns true if the given field is exported.
+func (f *Field) IsExported() bool {
+	return f.field.PkgPath == ""
+}
+
+// IsZero returns true if the given field is not initialized (has a zero value).
+// It panics if the field is not exported.
+func (f *Field) IsZero() bool {
+	zero := reflect.Zero(f.value.Type()).Interface()
+	current := f.Value()
+
+	return reflect.DeepEqual(current, zero)
+}
+
+// Name returns the name of the given field
+func (f *Field) Name() string {
+	return f.field.Name
+}
+
+// Kind returns the fields kind, such as "string", "map", "bool", etc ..
+func (f *Field) Kind() reflect.Kind {
+	return f.value.Kind()
+}
+
+// Set sets the field to given value v. It returns an error if the field is not
+// settable (not addressable or not exported) or if the given value's type
+// doesn't match the fields type.
+func (f *Field) Set(val interface{}) error {
+	// we can't set unexported fields, so be sure this field is exported
+	if !f.IsExported() {
+		return errNotExported
+	}
+
+	// do we get here? not sure...
+	if !f.value.CanSet() {
+		return errNotSettable
+	}
+
+	given := reflect.ValueOf(val)
+
+	if f.value.Kind() != given.Kind() {
+		return fmt.Errorf("wrong kind. got: %s want: %s", given.Kind(), f.value.Kind())
+	}
+
+	f.value.Set(given)
+	return nil
+}
+
+// Zero sets the field to its zero value. It returns an error if the field is not
+// settable (not addressable or not exported).
+func (f *Field) Zero() error {
+	zero := reflect.Zero(f.value.Type()).Interface()
+	return f.Set(zero)
+}
+
+// Fields returns a slice of Fields. This is particular handy to get the fields
+// of a nested struct . A struct tag with the content of "-" ignores the
+// checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field *http.Request `structs:"-"`
+//
+// It panics if field is not exported or if field's kind is not struct
+func (f *Field) Fields() []*Field {
+	return getFields(f.value, f.defaultTag)
+}
+
+// Field returns the field from a nested struct. It panics if the nested struct
+// is not exported or if the field was not found.
+func (f *Field) Field(name string) *Field {
+	field, ok := f.FieldOk(name)
+	if !ok {
+		panic("field not found")
+	}
+
+	return field
+}
+
+// FieldOk returns the field from a nested struct. The boolean returns whether
+// the field was found (true) or not (false).
+func (f *Field) FieldOk(name string) (*Field, bool) {
+	value := &f.value
+	// value must be settable so we need to make sure it holds the address of the
+	// variable and not a copy, so we can pass the pointer to strctVal instead of a
+	// copy (which is not assigned to any variable, hence not settable).
+	// see "https://blog.golang.org/laws-of-reflection#TOC_8."
+	if f.value.Kind() != reflect.Ptr {
+		a := f.value.Addr()
+		value = &a
+	}
+	v := strctVal(value.Interface())
+	t := v.Type()
+
+	field, ok := t.FieldByName(name)
+	if !ok {
+		return nil, false
+	}
+
+	return &Field{
+		field: field,
+		value: v.FieldByName(name),
+	}, true
+}

--- a/internal/structs/field_test.go
+++ b/internal/structs/field_test.go
@@ -1,0 +1,397 @@
+package structs
+
+import (
+	"reflect"
+	"testing"
+)
+
+// A test struct that defines all cases
+type Foo struct {
+	A    string
+	B    int    `structs:"y"`
+	C    bool   `json:"c"`
+	d    string // not exported
+	E    *Baz
+	x    string `xml:"x"` // not exported, with tag
+	Y    []string
+	Z    map[string]interface{}
+	*Bar // embedded
+}
+
+type Baz struct {
+	A string
+	B int
+}
+
+type Bar struct {
+	E string
+	F int
+	g []string
+}
+
+func newStruct() *Struct {
+	b := &Bar{
+		E: "example",
+		F: 2,
+		g: []string{"zeynep", "fatih"},
+	}
+
+	// B and x is not initialized for testing
+	f := &Foo{
+		A: "gopher",
+		C: true,
+		d: "small",
+		E: nil,
+		Y: []string{"example"},
+		Z: nil,
+	}
+	f.Bar = b
+
+	return New(f)
+}
+
+func TestField_Set(t *testing.T) {
+	s := newStruct()
+
+	f := s.Field("A")
+	err := f.Set("fatih")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if f.Value().(string) != "fatih" {
+		t.Errorf("Setted value is wrong: %s want: %s", f.Value().(string), "fatih")
+	}
+
+	f = s.Field("Y")
+	err = f.Set([]string{"override", "with", "this"})
+	if err != nil {
+		t.Error(err)
+	}
+
+	sliceLen := len(f.Value().([]string))
+	if sliceLen != 3 {
+		t.Errorf("Setted values slice length is wrong: %d, want: %d", sliceLen, 3)
+	}
+
+	f = s.Field("C")
+	err = f.Set(false)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if f.Value().(bool) {
+		t.Errorf("Setted value is wrong: %t want: %t", f.Value().(bool), false)
+	}
+
+	// let's pass a different type
+	f = s.Field("A")
+	err = f.Set(123) // Field A is of type string, but we are going to pass an integer
+	if err == nil {
+		t.Error("Setting a field's value with a different type than the field's type should return an error")
+	}
+
+	// old value should be still there :)
+	if f.Value().(string) != "fatih" {
+		t.Errorf("Setted value is wrong: %s want: %s", f.Value().(string), "fatih")
+	}
+
+	// let's access an unexported field, which should give an error
+	f = s.Field("d")
+	err = f.Set("large")
+	if err != errNotExported {
+		t.Error(err)
+	}
+
+	// let's set a pointer to struct
+	b := &Bar{
+		E: "gopher",
+		F: 2,
+	}
+
+	f = s.Field("Bar")
+	err = f.Set(b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	baz := &Baz{
+		A: "helloWorld",
+		B: 42,
+	}
+
+	f = s.Field("E")
+	err = f.Set(baz)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ba := s.Field("E").Value().(*Baz)
+
+	if ba.A != "helloWorld" {
+		t.Errorf("could not set baz. Got: %s Want: helloWorld", ba.A)
+	}
+}
+
+func TestField_NotSettable(t *testing.T) {
+	a := map[int]Baz{
+		4: {
+			A: "value",
+		},
+	}
+
+	s := New(a[4])
+
+	if err := s.Field("A").Set("newValue"); err != errNotSettable {
+		t.Errorf("Trying to set non-settable field should error with %q. Got %q instead.", errNotSettable, err)
+	}
+}
+
+func TestField_Zero(t *testing.T) {
+	s := newStruct()
+
+	f := s.Field("A")
+	err := f.Zero()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if f.Value().(string) != "" {
+		t.Errorf("Zeroed value is wrong: %s want: %s", f.Value().(string), "")
+	}
+
+	f = s.Field("Y")
+	err = f.Zero()
+	if err != nil {
+		t.Error(err)
+	}
+
+	sliceLen := len(f.Value().([]string))
+	if sliceLen != 0 {
+		t.Errorf("Zeroed values slice length is wrong: %d, want: %d", sliceLen, 0)
+	}
+
+	f = s.Field("C")
+	err = f.Zero()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if f.Value().(bool) {
+		t.Errorf("Zeroed value is wrong: %t want: %t", f.Value().(bool), false)
+	}
+
+	// let's access an unexported field, which should give an error
+	f = s.Field("d")
+	err = f.Zero()
+	if err != errNotExported {
+		t.Error(err)
+	}
+
+	f = s.Field("Bar")
+	err = f.Zero()
+	if err != nil {
+		t.Error(err)
+	}
+
+	f = s.Field("E")
+	err = f.Zero()
+	if err != nil {
+		t.Error(err)
+	}
+
+	v := s.Field("E").value
+	if !v.IsNil() {
+		t.Errorf("could not set baz. Got: %s Want: <nil>", v.Interface())
+	}
+}
+
+func TestField(t *testing.T) {
+	s := newStruct()
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("Retrieveing a non existing field from the struct should panic")
+		}
+	}()
+
+	_ = s.Field("no-field")
+}
+
+func TestField_Kind(t *testing.T) {
+	s := newStruct()
+
+	f := s.Field("A")
+	if f.Kind() != reflect.String {
+		t.Errorf("Field A has wrong kind: %s want: %s", f.Kind(), reflect.String)
+	}
+
+	f = s.Field("B")
+	if f.Kind() != reflect.Int {
+		t.Errorf("Field B has wrong kind: %s want: %s", f.Kind(), reflect.Int)
+	}
+
+	// unexported
+	f = s.Field("d")
+	if f.Kind() != reflect.String {
+		t.Errorf("Field d has wrong kind: %s want: %s", f.Kind(), reflect.String)
+	}
+}
+
+func TestField_Tag(t *testing.T) {
+	s := newStruct()
+
+	v := s.Field("B").Tag("json")
+	if v != "" {
+		t.Errorf("Field's tag value of a non existing tag should return empty, got: %s", v)
+	}
+
+	v = s.Field("C").Tag("json")
+	if v != "c" {
+		t.Errorf("Field's tag value of the existing field C should return 'c', got: %s", v)
+	}
+
+	v = s.Field("d").Tag("json")
+	if v != "" {
+		t.Errorf("Field's tag value of a non exported field should return empty, got: %s", v)
+	}
+
+	v = s.Field("x").Tag("xml")
+	if v != "x" {
+		t.Errorf("Field's tag value of a non exported field with a tag should return 'x', got: %s", v)
+	}
+
+	v = s.Field("A").Tag("json")
+	if v != "" {
+		t.Errorf("Field's tag value of a existing field without a tag should return empty, got: %s", v)
+	}
+}
+
+func TestField_Value(t *testing.T) {
+	s := newStruct()
+
+	v := s.Field("A").Value()
+	val, ok := v.(string)
+	if !ok {
+		t.Errorf("Field's value of a A should be string")
+	}
+
+	if val != "gopher" {
+		t.Errorf("Field's value of a existing tag should return 'gopher', got: %s", val)
+	}
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("Value of a non exported field from the field should panic")
+		}
+	}()
+
+	// should panic
+	_ = s.Field("d").Value()
+}
+
+func TestField_IsEmbedded(t *testing.T) {
+	s := newStruct()
+
+	if !s.Field("Bar").IsEmbedded() {
+		t.Errorf("Fields 'Bar' field is an embedded field")
+	}
+
+	if s.Field("d").IsEmbedded() {
+		t.Errorf("Fields 'd' field is not an embedded field")
+	}
+}
+
+func TestField_IsExported(t *testing.T) {
+	s := newStruct()
+
+	if !s.Field("Bar").IsExported() {
+		t.Errorf("Fields 'Bar' field is an exported field")
+	}
+
+	if !s.Field("A").IsExported() {
+		t.Errorf("Fields 'A' field is an exported field")
+	}
+
+	if s.Field("d").IsExported() {
+		t.Errorf("Fields 'd' field is not an exported field")
+	}
+}
+
+func TestField_IsZero(t *testing.T) {
+	s := newStruct()
+
+	if s.Field("A").IsZero() {
+		t.Errorf("Fields 'A' field is an initialized field")
+	}
+
+	if !s.Field("B").IsZero() {
+		t.Errorf("Fields 'B' field is not an initialized field")
+	}
+}
+
+func TestField_Name(t *testing.T) {
+	s := newStruct()
+
+	if s.Field("A").Name() != "A" {
+		t.Errorf("Fields 'A' field should have the name 'A'")
+	}
+}
+
+func TestField_Field(t *testing.T) {
+	s := newStruct()
+
+	e := s.Field("Bar").Field("E")
+
+	val, ok := e.Value().(string)
+	if !ok {
+		t.Error("The value of the field 'e' inside 'Bar' struct should be string")
+	}
+
+	if val != "example" {
+		t.Errorf("The value of 'e' should be 'example, got: %s", val)
+	}
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("Field of a non existing nested struct should panic")
+		}
+	}()
+
+	_ = s.Field("Bar").Field("e")
+}
+
+func TestField_Fields(t *testing.T) {
+	s := newStruct()
+	fields := s.Field("Bar").Fields()
+
+	if len(fields) != 3 {
+		t.Errorf("We expect 3 fields in embedded struct, was: %d", len(fields))
+	}
+}
+
+func TestField_FieldOk(t *testing.T) {
+	s := newStruct()
+
+	b, ok := s.FieldOk("Bar")
+	if !ok {
+		t.Error("The field 'Bar' should exists.")
+	}
+
+	e, ok := b.FieldOk("E")
+	if !ok {
+		t.Error("The field 'E' should exists.")
+	}
+
+	val, ok := e.Value().(string)
+	if !ok {
+		t.Error("The value of the field 'e' inside 'Bar' struct should be string")
+	}
+
+	if val != "example" {
+		t.Errorf("The value of 'e' should be 'example, got: %s", val)
+	}
+}

--- a/internal/structs/structs.go
+++ b/internal/structs/structs.go
@@ -1,0 +1,598 @@
+// Package structs contains various utilities functions to work with structs.
+package structs
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+var (
+	// DefaultTagName is the default tag name for struct fields which provides
+	// a more granular to tweak certain structs. Lookup the necessary functions
+	// for more info.
+	DefaultTagName = "structs" // struct's field default tag name
+)
+
+// Struct encapsulates a struct type to provide several high level functions
+// around the struct.
+type Struct struct {
+	raw     interface{}
+	value   reflect.Value
+	TagName string
+}
+
+// New returns a new *Struct with the struct s. It panics if the s's kind is
+// not struct.
+func New(s interface{}) *Struct {
+	return &Struct{
+		raw:     s,
+		value:   strctVal(s),
+		TagName: DefaultTagName,
+	}
+}
+
+// Map converts the given struct to a map[string]interface{}, where the keys
+// of the map are the field names and the values of the map the associated
+// values of the fields. The default key string is the struct field name but
+// can be changed in the struct field's tag value. The "structs" key in the
+// struct's field tag value is the key name. Example:
+//
+//   // Field appears in map as key "myName".
+//   Name string `structs:"myName"`
+//
+// A tag value with the content of "-" ignores that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A tag value with the content of "string" uses the stringer to get the value. Example:
+//
+//   // The value will be output of Animal's String() func.
+//   // Map will panic if Animal does not implement String().
+//   Field *Animal `structs:"field,string"`
+//
+// A tag value with the option of "flatten" used in a struct field is to flatten its fields
+// in the output map. Example:
+//
+//   // The FieldStruct's fields will be flattened into the output map.
+//   FieldStruct time.Time `structs:",flatten"`
+//
+// A tag value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// A tag value with the option of "omitempty" ignores that particular field if
+// the field value is empty. Example:
+//
+//   // Field appears in map as key "myName", but the field is
+//   // skipped if empty.
+//   Field string `structs:"myName,omitempty"`
+//
+//   // Field appears in map as key "Field" (the default), but
+//   // the field is skipped if empty.
+//   Field string `structs:",omitempty"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields will be neglected.
+func (s *Struct) Map() map[string]interface{} {
+	out := make(map[string]interface{})
+	s.FillMap(out)
+	return out
+}
+
+// FillMap is the same as Map. Instead of returning the output, it fills the
+// given map.
+func (s *Struct) FillMap(out map[string]interface{}) {
+	if out == nil {
+		return
+	}
+
+	fields := s.structFields()
+
+	for _, field := range fields {
+		name := field.Name
+
+		val := s.value.FieldByName(name)
+		isSubStruct := false
+		var finalVal interface{}
+
+		tagName, tagOpts := parseTag(field.Tag.Get(s.TagName))
+		if tagName != "" {
+			name = tagName
+		}
+
+		// prefer json tag
+		json := field.Tag.Get("json")
+		if json != "" {
+			if strings.Contains(json, ",") {
+				split := strings.Split(json, ",")
+				if len(split) > 0 {
+					name = strings.TrimSpace(split[0])
+				}
+			} else {
+				name = json
+			}
+		}
+
+		// if the value is a zero value and the field is marked as omitempty do
+		// not include
+		if tagOpts.Has("omitempty") {
+			zero := reflect.Zero(val.Type()).Interface()
+			current := val.Interface()
+
+			if reflect.DeepEqual(current, zero) {
+				continue
+			}
+		}
+
+		if !tagOpts.Has("omitnested") {
+			finalVal = s.nested(val)
+
+			v := reflect.ValueOf(val.Interface())
+			if v.Kind() == reflect.Ptr {
+				v = v.Elem()
+			}
+
+			switch v.Kind() {
+			case reflect.Map, reflect.Struct:
+				isSubStruct = true
+			}
+		} else {
+			finalVal = val.Interface()
+		}
+
+		if tagOpts.Has("string") {
+			s, ok := val.Interface().(fmt.Stringer)
+			if ok {
+				out[name] = s.String()
+			}
+			continue
+		}
+
+		if isSubStruct && (tagOpts.Has("flatten")) {
+			for k := range finalVal.(map[string]interface{}) {
+				out[k] = finalVal.(map[string]interface{})[k]
+			}
+		} else {
+			out[name] = finalVal
+		}
+	}
+}
+
+// Values converts the given s struct's field values to a []interface{}.  A
+// struct tag with the content of "-" ignores the that particular field.
+// Example:
+//
+//   // Field is ignored by this package.
+//   Field int `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Fields is not processed further by this package.
+//   Field time.Time     `structs:",omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// A tag value with the option of "omitempty" ignores that particular field and
+// is not added to the values if the field value is empty. Example:
+//
+//   // Field is skipped if empty
+//   Field string `structs:",omitempty"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected.
+func (s *Struct) Values() []interface{} {
+	fields := s.structFields()
+
+	var t []interface{}
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		// if the value is a zero value and the field is marked as omitempty do
+		// not include
+		if tagOpts.Has("omitempty") {
+			zero := reflect.Zero(val.Type()).Interface()
+			current := val.Interface()
+
+			if reflect.DeepEqual(current, zero) {
+				continue
+			}
+		}
+
+		if tagOpts.Has("string") {
+			s, ok := val.Interface().(fmt.Stringer)
+			if ok {
+				t = append(t, s.String())
+			}
+			continue
+		}
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			// look out for embedded structs, and convert them to a
+			// []interface{} to be added to the final values slice
+			t = append(t, Values(val.Interface())...)
+		} else {
+			t = append(t, val.Interface())
+		}
+	}
+
+	return t
+}
+
+// Fields returns a slice of Fields. A struct tag with the content of "-"
+// ignores the checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// It panics if s's kind is not struct.
+func (s *Struct) Fields() []*Field {
+	return getFields(s.value, s.TagName)
+}
+
+// Names returns a slice of field names. A struct tag with the content of "-"
+// ignores the checking of that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// It panics if s's kind is not struct.
+func (s *Struct) Names() []string {
+	fields := getFields(s.value, s.TagName)
+
+	names := make([]string, len(fields))
+
+	for i, field := range fields {
+		names[i] = field.Name()
+	}
+
+	return names
+}
+
+func getFields(v reflect.Value, tagName string) []*Field {
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	t := v.Type()
+
+	var fields []*Field
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if tag := field.Tag.Get(tagName); tag == "-" {
+			continue
+		}
+
+		f := &Field{
+			field: field,
+			value: v.FieldByName(field.Name),
+		}
+
+		fields = append(fields, f)
+
+	}
+
+	return fields
+}
+
+// Field returns a new Field struct that provides several high level functions
+// around a single struct field entity. It panics if the field is not found.
+func (s *Struct) Field(name string) *Field {
+	f, ok := s.FieldOk(name)
+	if !ok {
+		panic("field not found")
+	}
+
+	return f
+}
+
+// FieldOk returns a new Field struct that provides several high level functions
+// around a single struct field entity. The boolean returns true if the field
+// was found.
+func (s *Struct) FieldOk(name string) (*Field, bool) {
+	t := s.value.Type()
+
+	field, ok := t.FieldByName(name)
+	if !ok {
+		return nil, false
+	}
+
+	return &Field{
+		field:      field,
+		value:      s.value.FieldByName(name),
+		defaultTag: s.TagName,
+	}, true
+}
+
+// IsZero returns true if all fields in a struct is a zero value (not
+// initialized) A struct tag with the content of "-" ignores the checking of
+// that particular field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected. It panics if s's kind is not struct.
+func (s *Struct) IsZero() bool {
+	fields := s.structFields()
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			ok := IsZero(val.Interface())
+			if !ok {
+				return false
+			}
+
+			continue
+		}
+
+		// zero value of the given field, such as "" for string, 0 for int
+		zero := reflect.Zero(val.Type()).Interface()
+
+		//  current value of the given field
+		current := val.Interface()
+
+		if !reflect.DeepEqual(current, zero) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// HasZero returns true if a field in a struct is not initialized (zero value).
+// A struct tag with the content of "-" ignores the checking of that particular
+// field. Example:
+//
+//   // Field is ignored by this package.
+//   Field bool `structs:"-"`
+//
+// A value with the option of "omitnested" stops iterating further if the type
+// is a struct. Example:
+//
+//   // Field is not processed further by this package.
+//   Field time.Time     `structs:"myName,omitnested"`
+//   Field *http.Request `structs:",omitnested"`
+//
+// Note that only exported fields of a struct can be accessed, non exported
+// fields  will be neglected. It panics if s's kind is not struct.
+func (s *Struct) HasZero() bool {
+	fields := s.structFields()
+
+	for _, field := range fields {
+		val := s.value.FieldByName(field.Name)
+
+		_, tagOpts := parseTag(field.Tag.Get(s.TagName))
+
+		if IsStruct(val.Interface()) && !tagOpts.Has("omitnested") {
+			ok := HasZero(val.Interface())
+			if ok {
+				return true
+			}
+
+			continue
+		}
+
+		// zero value of the given field, such as "" for string, 0 for int
+		zero := reflect.Zero(val.Type()).Interface()
+
+		//  current value of the given field
+		current := val.Interface()
+
+		if reflect.DeepEqual(current, zero) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Name returns the structs's type name within its package. For more info refer
+// to Name() function.
+func (s *Struct) Name() string {
+	return s.value.Type().Name()
+}
+
+// structFields returns the exported struct fields for a given s struct. This
+// is a convenient helper method to avoid duplicate code in some of the
+// functions.
+func (s *Struct) structFields() []reflect.StructField {
+	t := s.value.Type()
+
+	var f []reflect.StructField
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		// we can't access the value of unexported fields
+		if field.PkgPath != "" {
+			continue
+		}
+
+		// don't check if it's omitted
+		if tag := field.Tag.Get(s.TagName); tag == "-" {
+			continue
+		}
+
+		f = append(f, field)
+	}
+
+	return f
+}
+
+func strctVal(s interface{}) reflect.Value {
+	v := reflect.ValueOf(s)
+
+	// if pointer get the underlying element≤
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		panic("not struct")
+	}
+
+	return v
+}
+
+// Map converts the given struct to a map[string]interface{}. For more info
+// refer to Struct types Map() method. It panics if s's kind is not struct.
+func Map(s interface{}) map[string]interface{} {
+	return New(s).Map()
+}
+
+// FillMap is the same as Map. Instead of returning the output, it fills the
+// given map.
+func FillMap(s interface{}, out map[string]interface{}) {
+	New(s).FillMap(out)
+}
+
+// Values converts the given struct to a []interface{}. For more info refer to
+// Struct types Values() method.  It panics if s's kind is not struct.
+func Values(s interface{}) []interface{} {
+	return New(s).Values()
+}
+
+// Fields returns a slice of *Field. For more info refer to Struct types
+// Fields() method.  It panics if s's kind is not struct.
+func Fields(s interface{}) []*Field {
+	return New(s).Fields()
+}
+
+// Names returns a slice of field names. For more info refer to Struct types
+// Names() method.  It panics if s's kind is not struct.
+func Names(s interface{}) []string {
+	return New(s).Names()
+}
+
+// IsZero returns true if all fields is equal to a zero value. For more info
+// refer to Struct types IsZero() method.  It panics if s's kind is not struct.
+func IsZero(s interface{}) bool {
+	return New(s).IsZero()
+}
+
+// HasZero returns true if any field is equal to a zero value. For more info
+// refer to Struct types HasZero() method.  It panics if s's kind is not struct.
+func HasZero(s interface{}) bool {
+	return New(s).HasZero()
+}
+
+// IsStruct returns true if the given variable is a struct or a pointer to
+// struct.
+func IsStruct(s interface{}) bool {
+	v := reflect.ValueOf(s)
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	// uninitialized zero value of a struct
+	if v.Kind() == reflect.Invalid {
+		return false
+	}
+
+	return v.Kind() == reflect.Struct
+}
+
+// Name returns the structs's type name within its package. It returns an
+// empty string for unnamed types. It panics if s's kind is not struct.
+func Name(s interface{}) string {
+	return New(s).Name()
+}
+
+// nested retrieves recursively all types for the given value and returns the
+// nested value.
+func (s *Struct) nested(val reflect.Value) interface{} {
+	var finalVal interface{}
+
+	v := reflect.ValueOf(val.Interface())
+	if v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	switch v.Kind() {
+	case reflect.Struct:
+		n := New(val.Interface())
+		n.TagName = s.TagName
+		m := n.Map()
+
+		// do not add the converted value if there are no exported fields, ie:
+		// time.Time
+		if len(m) == 0 {
+			finalVal = val.Interface()
+		} else {
+			finalVal = m
+		}
+	case reflect.Map:
+		// get the element type of the map
+		mapElem := val.Type()
+		switch val.Type().Kind() {
+		case reflect.Ptr, reflect.Array, reflect.Map,
+			reflect.Slice, reflect.Chan:
+			mapElem = val.Type().Elem()
+			if mapElem.Kind() == reflect.Ptr {
+				mapElem = mapElem.Elem()
+			}
+		}
+
+		// only iterate over struct types, ie: map[string]StructType,
+		// map[string][]StructType,
+		if mapElem.Kind() == reflect.Struct ||
+			(mapElem.Kind() == reflect.Slice &&
+				mapElem.Elem().Kind() == reflect.Struct) {
+			m := make(map[string]interface{}, val.Len())
+			for _, k := range val.MapKeys() {
+				m[k.String()] = s.nested(val.MapIndex(k))
+			}
+			finalVal = m
+			break
+		}
+
+		// TODO(arslan): should this be optional?
+		finalVal = val.Interface()
+	case reflect.Slice, reflect.Array:
+		if val.Type().Kind() == reflect.Interface {
+			finalVal = val.Interface()
+			break
+		}
+
+		// TODO(arslan): should this be optional?
+		// do not iterate of non struct types, just pass the value. Ie: []int,
+		// []string, co... We only iterate further if it's a struct.
+		// i.e []foo or []*foo
+		if val.Type().Elem().Kind() != reflect.Struct &&
+			!(val.Type().Elem().Kind() == reflect.Ptr &&
+				val.Type().Elem().Elem().Kind() == reflect.Struct) {
+			finalVal = val.Interface()
+			break
+		}
+
+		slices := make([]interface{}, val.Len())
+		for x := 0; x < val.Len(); x++ {
+			slices[x] = s.nested(val.Index(x))
+		}
+		finalVal = slices
+	default:
+		finalVal = val.Interface()
+	}
+
+	return finalVal
+}

--- a/internal/structs/structs_example_test.go
+++ b/internal/structs/structs_example_test.go
@@ -1,0 +1,351 @@
+package structs
+
+import (
+	"fmt"
+	"time"
+)
+
+func ExampleNew() {
+	type Server struct {
+		Name    string
+		ID      int32
+		Enabled bool
+	}
+
+	server := &Server{
+		Name:    "Arslan",
+		ID:      123456,
+		Enabled: true,
+	}
+
+	s := New(server)
+
+	fmt.Printf("Name        : %v\n", s.Name())
+	fmt.Printf("Values      : %v\n", s.Values())
+	fmt.Printf("Value of ID : %v\n", s.Field("ID").Value())
+	// Output:
+	// Name        : Server
+	// Values      : [Arslan 123456 true]
+	// Value of ID : 123456
+
+}
+
+func ExampleMap() {
+	type Server struct {
+		Name    string
+		ID      int32
+		Enabled bool
+	}
+
+	s := &Server{
+		Name:    "Arslan",
+		ID:      123456,
+		Enabled: true,
+	}
+
+	m := Map(s)
+
+	fmt.Printf("%#v\n", m["Name"])
+	fmt.Printf("%#v\n", m["ID"])
+	fmt.Printf("%#v\n", m["Enabled"])
+	// Output:
+	// "Arslan"
+	// 123456
+	// true
+
+}
+
+func ExampleMap_tags() {
+	// Custom tags can change the map keys instead of using the fields name
+	type Server struct {
+		Name    string `structs:"server_name"`
+		ID      int32  `structs:"server_id"`
+		Enabled bool   `structs:"enabled"`
+	}
+
+	s := &Server{
+		Name: "Zeynep",
+		ID:   789012,
+	}
+
+	m := Map(s)
+
+	// access them by the custom tags defined above
+	fmt.Printf("%#v\n", m["server_name"])
+	fmt.Printf("%#v\n", m["server_id"])
+	fmt.Printf("%#v\n", m["enabled"])
+	// Output:
+	// "Zeynep"
+	// 789012
+	// false
+
+}
+
+func ExampleMap_omitNested() {
+	// By default field with struct types are processed too. We can stop
+	// processing them via "omitnested" tag option.
+	type Server struct {
+		Name string    `structs:"server_name"`
+		ID   int32     `structs:"server_id"`
+		Time time.Time `structs:"time,omitnested"` // do not convert to map[string]interface{}
+	}
+
+	const shortForm = "2006-Jan-02"
+	t, _ := time.Parse("2006-Jan-02", "2013-Feb-03")
+
+	s := &Server{
+		Name: "Zeynep",
+		ID:   789012,
+		Time: t,
+	}
+
+	m := Map(s)
+
+	// access them by the custom tags defined above
+	fmt.Printf("%v\n", m["server_name"])
+	fmt.Printf("%v\n", m["server_id"])
+	fmt.Printf("%v\n", m["time"].(time.Time))
+	// Output:
+	// Zeynep
+	// 789012
+	// 2013-02-03 00:00:00 +0000 UTC
+}
+
+func ExampleMap_omitEmpty() {
+	// By default field with struct types of zero values are processed too. We
+	// can stop processing them via "omitempty" tag option.
+	type Server struct {
+		Name     string `structs:",omitempty"`
+		ID       int32  `structs:"server_id,omitempty"`
+		Location string
+	}
+
+	// Only add location
+	s := &Server{
+		Location: "Tokyo",
+	}
+
+	m := Map(s)
+
+	// map contains only the Location field
+	fmt.Printf("%v\n", m)
+	// Output:
+	// map[Location:Tokyo]
+}
+
+func ExampleValues() {
+	type Server struct {
+		Name    string
+		ID      int32
+		Enabled bool
+	}
+
+	s := &Server{
+		Name:    "Fatih",
+		ID:      135790,
+		Enabled: false,
+	}
+
+	m := Values(s)
+
+	fmt.Printf("Values: %+v\n", m)
+	// Output:
+	// Values: [Fatih 135790 false]
+}
+
+func ExampleValues_omitEmpty() {
+	// By default field with struct types of zero values are processed too. We
+	// can stop processing them via "omitempty" tag option.
+	type Server struct {
+		Name     string `structs:",omitempty"`
+		ID       int32  `structs:"server_id,omitempty"`
+		Location string
+	}
+
+	// Only add location
+	s := &Server{
+		Location: "Ankara",
+	}
+
+	m := Values(s)
+
+	// values contains only the Location field
+	fmt.Printf("Values: %+v\n", m)
+	// Output:
+	// Values: [Ankara]
+}
+
+func ExampleValues_tags() {
+	type Location struct {
+		City    string
+		Country string
+	}
+
+	type Server struct {
+		Name     string
+		ID       int32
+		Enabled  bool
+		Location Location `structs:"-"` // values from location are not included anymore
+	}
+
+	s := &Server{
+		Name:     "Fatih",
+		ID:       135790,
+		Enabled:  false,
+		Location: Location{City: "Ankara", Country: "Turkey"},
+	}
+
+	// Let get all values from the struct s. Note that we don't include values
+	// from the Location field
+	m := Values(s)
+
+	fmt.Printf("Values: %+v\n", m)
+	// Output:
+	// Values: [Fatih 135790 false]
+}
+
+func ExampleFields() {
+	type Access struct {
+		Name         string
+		LastAccessed time.Time
+		Number       int
+	}
+
+	s := &Access{
+		Name:         "Fatih",
+		LastAccessed: time.Now(),
+		Number:       1234567,
+	}
+
+	fields := Fields(s)
+
+	for i, field := range fields {
+		fmt.Printf("[%d] %+v\n", i, field.Name())
+	}
+
+	// Output:
+	// [0] Name
+	// [1] LastAccessed
+	// [2] Number
+}
+
+func ExampleFields_nested() {
+	type Person struct {
+		Name   string
+		Number int
+	}
+
+	type Access struct {
+		Person        Person
+		HasPermission bool
+		LastAccessed  time.Time
+	}
+
+	s := &Access{
+		Person:        Person{Name: "fatih", Number: 1234567},
+		LastAccessed:  time.Now(),
+		HasPermission: true,
+	}
+
+	// Let's get all fields from the struct s.
+	fields := Fields(s)
+
+	for _, field := range fields {
+		if field.Name() == "Person" {
+			fmt.Printf("Access.Person.Name: %+v\n", field.Field("Name").Value())
+		}
+	}
+
+	// Output:
+	// Access.Person.Name: fatih
+}
+
+func ExampleField() {
+	type Person struct {
+		Name   string
+		Number int
+	}
+
+	type Access struct {
+		Person        Person
+		HasPermission bool
+		LastAccessed  time.Time
+	}
+
+	access := &Access{
+		Person:        Person{Name: "fatih", Number: 1234567},
+		LastAccessed:  time.Now(),
+		HasPermission: true,
+	}
+
+	// Create a new Struct type
+	s := New(access)
+
+	// Get the Field type for "Person" field
+	p := s.Field("Person")
+
+	// Get the underlying "Name field" and print the value of it
+	name := p.Field("Name")
+
+	fmt.Printf("Value of Person.Access.Name: %+v\n", name.Value())
+
+	// Output:
+	// Value of Person.Access.Name: fatih
+
+}
+
+func ExampleIsZero() {
+	type Server struct {
+		Name    string
+		ID      int32
+		Enabled bool
+	}
+
+	// Nothing is initialized
+	a := &Server{}
+	isZeroA := IsZero(a)
+
+	// Name and Enabled is initialized, but not ID
+	b := &Server{
+		Name:    "Golang",
+		Enabled: true,
+	}
+	isZeroB := IsZero(b)
+
+	fmt.Printf("%#v\n", isZeroA)
+	fmt.Printf("%#v\n", isZeroB)
+	// Output:
+	// true
+	// false
+}
+
+func ExampleHasZero() {
+	// Let's define an Access struct. Note that the "Enabled" field is not
+	// going to be checked because we added the "structs" tag to the field.
+	type Access struct {
+		Name         string
+		LastAccessed time.Time
+		Number       int
+		Enabled      bool `structs:"-"`
+	}
+
+	// Name and Number is not initialized.
+	a := &Access{
+		LastAccessed: time.Now(),
+	}
+	hasZeroA := HasZero(a)
+
+	// Name and Number is initialized.
+	b := &Access{
+		Name:         "Fatih",
+		LastAccessed: time.Now(),
+		Number:       12345,
+	}
+	hasZeroB := HasZero(b)
+
+	fmt.Printf("%#v\n", hasZeroA)
+	fmt.Printf("%#v\n", hasZeroB)
+	// Output:
+	// true
+	// false
+}

--- a/internal/structs/structs_test.go
+++ b/internal/structs/structs_test.go
@@ -1,0 +1,1453 @@
+package structs
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestMapNonStruct(t *testing.T) {
+	foo := []string{"foo"}
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("Passing a non struct into Map should panic")
+		}
+	}()
+
+	// this should panic. We are going to recover and and test it
+	_ = Map(foo)
+}
+
+func TestStructIndexes(t *testing.T) {
+	type C struct {
+		something int
+		Props     map[string]interface{}
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Using mixed indexes should not panic")
+		}
+	}()
+
+	// They should not panic
+	_ = Map(&C{})
+	_ = Fields(&C{})
+	_ = Values(&C{})
+	_ = IsZero(&C{})
+	_ = HasZero(&C{})
+}
+
+func TestMap(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	a := Map(T)
+
+	if typ := reflect.TypeOf(a).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	// we have three fields
+	if len(a) != 3 {
+		t.Errorf("Map should return a map of len 3, got: %d", len(a))
+	}
+
+	inMap := func(val interface{}) bool {
+		for _, v := range a {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, val := range []interface{}{"a-value", 2, true} {
+		if !inMap(val) {
+			t.Errorf("Map should have the value %v", val)
+		}
+	}
+
+}
+
+func TestMap_Tag(t *testing.T) {
+	var T = struct {
+		A string `structs:"x"`
+		B int    `structs:"y"`
+		C bool   `structs:"z"`
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	a := Map(T)
+
+	inMap := func(key interface{}) bool {
+		for k := range a {
+			if reflect.DeepEqual(k, key) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, key := range []string{"x", "y", "z"} {
+		if !inMap(key) {
+			t.Errorf("Map should have the key %v", key)
+		}
+	}
+
+}
+
+func TestMap_CustomTag(t *testing.T) {
+	var T = struct {
+		A string `json:"x"`
+		B int    `json:"y"`
+		C bool   `json:"z"`
+		D struct {
+			E string `json:"jkl"`
+		} `json:"nested"`
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+	T.D.E = "e-value"
+
+	s := New(T)
+	s.TagName = "json"
+
+	a := s.Map()
+
+	inMap := func(key interface{}) bool {
+		for k := range a {
+			if reflect.DeepEqual(k, key) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, key := range []string{"x", "y", "z"} {
+		if !inMap(key) {
+			t.Errorf("Map should have the key %v", key)
+		}
+	}
+
+	nested, ok := a["nested"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Map should contain the D field that is tagged as 'nested'")
+	}
+
+	e, ok := nested["jkl"].(string)
+	if !ok {
+		t.Fatalf("Map should contain the D.E field that is tagged as 'jkl'")
+	}
+
+	if e != "e-value" {
+		t.Errorf("D.E field should be equal to 'e-value', got: '%v'", e)
+	}
+
+}
+
+func TestMap_MultipleCustomTag(t *testing.T) {
+	var A = struct {
+		X string `aa:"ax"`
+	}{"a_value"}
+
+	aStruct := New(A)
+	aStruct.TagName = "aa"
+
+	var B = struct {
+		X string `bb:"bx"`
+	}{"b_value"}
+
+	bStruct := New(B)
+	bStruct.TagName = "bb"
+
+	a, b := aStruct.Map(), bStruct.Map()
+	if !reflect.DeepEqual(a, map[string]interface{}{"ax": "a_value"}) {
+		t.Error("Map should have field ax with value a_value")
+	}
+
+	if !reflect.DeepEqual(b, map[string]interface{}{"bx": "b_value"}) {
+		t.Error("Map should have field bx with value b_value")
+	}
+}
+
+func TestMap_OmitEmpty(t *testing.T) {
+	type A struct {
+		Name  string
+		Value string    `structs:",omitempty"`
+		Time  time.Time `structs:",omitempty"`
+	}
+	a := A{}
+
+	m := Map(a)
+
+	_, ok := m["Value"].(map[string]interface{})
+	if ok {
+		t.Error("Map should not contain the Value field that is tagged as omitempty")
+	}
+
+	_, ok = m["Time"].(map[string]interface{})
+	if ok {
+		t.Error("Map should not contain the Time field that is tagged as omitempty")
+	}
+}
+
+func TestMap_OmitNested(t *testing.T) {
+	type A struct {
+		Name  string
+		Value string
+		Time  time.Time `structs:",omitnested"`
+	}
+	a := A{Time: time.Now()}
+
+	type B struct {
+		Desc string
+		A    A
+	}
+	b := &B{A: a}
+
+	m := Map(b)
+
+	in, ok := m["A"].(map[string]interface{})
+	if !ok {
+		t.Error("Map nested structs is not available in the map")
+	}
+
+	// should not happen
+	if _, ok := in["Time"].(map[string]interface{}); ok {
+		t.Error("Map nested struct should omit recursiving parsing of Time")
+	}
+
+	if _, ok := in["Time"].(time.Time); !ok {
+		t.Error("Map nested struct should stop parsing of Time at is current value")
+	}
+}
+
+func TestMap_Nested(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := &A{Name: "example"}
+
+	type B struct {
+		A *A
+	}
+	b := &B{A: a}
+
+	m := Map(b)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["A"].(map[string]interface{})
+	if !ok {
+		t.Error("Map nested structs is not available in the map")
+	}
+
+	if name := in["Name"].(string); name != "example" {
+		t.Errorf("Map nested struct's name field should give example, got: %s", name)
+	}
+}
+
+func TestMap_NestedMapWithStructValues(t *testing.T) {
+	type A struct {
+		Name string
+	}
+
+	type B struct {
+		A map[string]*A
+	}
+
+	a := &A{Name: "example"}
+
+	b := &B{
+		A: map[string]*A{
+			"example_key": a,
+		},
+	}
+
+	m := Map(b)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["A"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["A"])
+	}
+
+	example := in["example_key"].(map[string]interface{})
+	if name := example["Name"].(string); name != "example" {
+		t.Errorf("Map nested struct's name field should give example, got: %s", name)
+	}
+}
+
+func TestMap_NestedMapWithStringValues(t *testing.T) {
+	type B struct {
+		Foo map[string]string
+	}
+
+	type A struct {
+		B *B
+	}
+
+	b := &B{
+		Foo: map[string]string{
+			"example_key": "example",
+		},
+	}
+
+	a := &A{B: b}
+
+	m := Map(a)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["B"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["B"])
+	}
+
+	foo := in["Foo"].(map[string]string)
+	if name := foo["example_key"]; name != "example" {
+		t.Errorf("Map nested struct's name field should give example, got: %s", name)
+	}
+}
+func TestMap_NestedMapWithInterfaceValues(t *testing.T) {
+	type B struct {
+		Foo map[string]interface{}
+	}
+
+	type A struct {
+		B *B
+	}
+
+	b := &B{
+		Foo: map[string]interface{}{
+			"example_key": "example",
+		},
+	}
+
+	a := &A{B: b}
+
+	m := Map(a)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["B"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["B"])
+	}
+
+	foo := in["Foo"].(map[string]interface{})
+	if name := foo["example_key"]; name != "example" {
+		t.Errorf("Map nested struct's name field should give example, got: %s", name)
+	}
+}
+
+func TestMap_NestedMapWithSliceIntValues(t *testing.T) {
+	type B struct {
+		Foo map[string][]int
+	}
+
+	type A struct {
+		B *B
+	}
+
+	b := &B{
+		Foo: map[string][]int{
+			"example_key": {80},
+		},
+	}
+
+	a := &A{B: b}
+
+	m := Map(a)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["B"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["B"])
+	}
+
+	foo := in["Foo"].(map[string][]int)
+	if name := foo["example_key"]; name[0] != 80 {
+		t.Errorf("Map nested struct's name field should give example, got: %v", name)
+	}
+}
+
+func TestMap_NestedMapWithSliceStructValues(t *testing.T) {
+	type address struct {
+		Country string `structs:"country"`
+	}
+
+	type B struct {
+		Foo map[string][]address
+	}
+
+	type A struct {
+		B *B
+	}
+
+	b := &B{
+		Foo: map[string][]address{
+			"example_key": {
+				{Country: "Turkey"},
+			},
+		},
+	}
+
+	a := &A{B: b}
+	m := Map(a)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["B"].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["B"])
+	}
+
+	foo := in["Foo"].(map[string]interface{})
+
+	addresses := foo["example_key"].([]interface{})
+
+	addr, ok := addresses[0].(map[string]interface{})
+	if !ok {
+		t.Errorf("Nested type of map should be of type map[string]interface{}, have %T", m["B"])
+	}
+
+	if _, exists := addr["country"]; !exists {
+		t.Errorf("Expecting country, but found Country")
+	}
+}
+
+func TestMap_NestedSliceWithStructValues(t *testing.T) {
+	type address struct {
+		Country string `structs:"customCountryName"`
+	}
+
+	type person struct {
+		Name      string    `structs:"name"`
+		Addresses []address `structs:"addresses"`
+	}
+
+	p := person{
+		Name: "test",
+		Addresses: []address{
+			{Country: "England"},
+			{Country: "Italy"},
+		},
+	}
+	mp := Map(p)
+
+	mpAddresses := mp["addresses"].([]interface{})
+	if _, exists := mpAddresses[0].(map[string]interface{})["Country"]; exists {
+		t.Errorf("Expecting customCountryName, but found Country")
+	}
+
+	if _, exists := mpAddresses[0].(map[string]interface{})["customCountryName"]; !exists {
+		t.Errorf("customCountryName key not found")
+	}
+}
+
+func TestMap_NestedSliceWithPointerOfStructValues(t *testing.T) {
+	type address struct {
+		Country string `structs:"customCountryName"`
+	}
+
+	type person struct {
+		Name      string     `structs:"name"`
+		Addresses []*address `structs:"addresses"`
+	}
+
+	p := person{
+		Name: "test",
+		Addresses: []*address{
+			{Country: "England"},
+			{Country: "Italy"},
+		},
+	}
+	mp := Map(p)
+
+	mpAddresses := mp["addresses"].([]interface{})
+	if _, exists := mpAddresses[0].(map[string]interface{})["Country"]; exists {
+		t.Errorf("Expecting customCountryName, but found Country")
+	}
+
+	if _, exists := mpAddresses[0].(map[string]interface{})["customCountryName"]; !exists {
+		t.Errorf("customCountryName key not found")
+	}
+}
+
+func TestMap_NestedSliceWithIntValues(t *testing.T) {
+	type person struct {
+		Name  string `structs:"name"`
+		Ports []int  `structs:"ports"`
+	}
+
+	p := person{
+		Name:  "test",
+		Ports: []int{80},
+	}
+	m := Map(p)
+
+	ports, ok := m["ports"].([]int)
+	if !ok {
+		t.Errorf("Nested type of map should be of type []int, have %T", m["ports"])
+	}
+
+	if ports[0] != 80 {
+		t.Errorf("Map nested struct's ports field should give 80, got: %v", ports)
+	}
+}
+
+func TestMap_Anonymous(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := &A{Name: "example"}
+
+	type B struct {
+		*A
+	}
+	b := &B{}
+	b.A = a
+
+	m := Map(b)
+
+	if typ := reflect.TypeOf(m).Kind(); typ != reflect.Map {
+		t.Errorf("Map should return a map type, got: %v", typ)
+	}
+
+	in, ok := m["A"].(map[string]interface{})
+	if !ok {
+		t.Error("Embedded structs is not available in the map")
+	}
+
+	if name := in["Name"].(string); name != "example" {
+		t.Errorf("Embedded A struct's Name field should give example, got: %s", name)
+	}
+}
+
+func TestMap_Flatnested(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A `structs:",flatten"`
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	m := Map(b)
+
+	_, ok := m["A"].(map[string]interface{})
+	if ok {
+		t.Error("Embedded A struct with tag flatten has to be flat in the map")
+	}
+
+	expectedMap := map[string]interface{}{"Name": "example", "C": 123}
+	if !reflect.DeepEqual(m, expectedMap) {
+		t.Errorf("The exprected map %+v does't correspond to %+v", expectedMap, m)
+	}
+
+}
+
+func TestMap_FlatnestedOverwrite(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A    `structs:",flatten"`
+		Name string
+		C    int
+	}
+	b := &B{C: 123, Name: "bName"}
+	b.A = a
+
+	m := Map(b)
+
+	_, ok := m["A"].(map[string]interface{})
+	if ok {
+		t.Error("Embedded A struct with tag flatten has to be flat in the map")
+	}
+
+	expectedMap := map[string]interface{}{"Name": "bName", "C": 123}
+	if !reflect.DeepEqual(m, expectedMap) {
+		t.Errorf("The exprected map %+v does't correspond to %+v", expectedMap, m)
+	}
+}
+
+func TestMap_TimeField(t *testing.T) {
+	type A struct {
+		CreatedAt time.Time
+	}
+
+	a := &A{CreatedAt: time.Now().UTC()}
+	m := Map(a)
+
+	_, ok := m["CreatedAt"].(time.Time)
+	if !ok {
+		t.Error("Time field must be final")
+	}
+}
+
+func TestFillMap(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	a := make(map[string]interface{}, 0)
+	FillMap(T, a)
+
+	// we have three fields
+	if len(a) != 3 {
+		t.Errorf("FillMap should fill a map of len 3, got: %d", len(a))
+	}
+
+	inMap := func(val interface{}) bool {
+		for _, v := range a {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	for _, val := range []interface{}{"a-value", 2, true} {
+		if !inMap(val) {
+			t.Errorf("FillMap should have the value %v", val)
+		}
+	}
+}
+
+func TestFillMap_Nil(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Error("FillMap should not panic if a nil map is passed")
+		}
+	}()
+
+	// nil should no
+	FillMap(T, nil)
+}
+func TestStruct(t *testing.T) {
+	var T = struct{}{}
+
+	if !IsStruct(T) {
+		t.Errorf("T should be a struct, got: %T", T)
+	}
+
+	if !IsStruct(&T) {
+		t.Errorf("T should be a struct, got: %T", T)
+	}
+
+}
+
+func TestValues(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	s := Values(T)
+
+	if typ := reflect.TypeOf(s).Kind(); typ != reflect.Slice {
+		t.Errorf("Values should return a slice type, got: %v", typ)
+	}
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{"a-value", 2, true} {
+		if !inSlice(val) {
+			t.Errorf("Values should have the value %v", val)
+		}
+	}
+}
+
+func TestValues_OmitEmpty(t *testing.T) {
+	type A struct {
+		Name  string
+		Value int `structs:",omitempty"`
+	}
+
+	a := A{Name: "example"}
+	s := Values(a)
+
+	if len(s) != 1 {
+		t.Errorf("Values of omitted empty fields should be not counted")
+	}
+
+	if s[0].(string) != "example" {
+		t.Errorf("Values of omitted empty fields should left the value example")
+	}
+}
+
+func TestValues_OmitNested(t *testing.T) {
+	type A struct {
+		Name  string
+		Value int
+	}
+
+	a := A{
+		Name:  "example",
+		Value: 123,
+	}
+
+	type B struct {
+		A A `structs:",omitnested"`
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	s := Values(b)
+
+	if len(s) != 2 {
+		t.Errorf("Values of omitted nested struct should be not counted")
+	}
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{123, a} {
+		if !inSlice(val) {
+			t.Errorf("Values should have the value %v", val)
+		}
+	}
+}
+
+func TestValues_Nested(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A A
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	s := Values(b)
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{"example", 123} {
+		if !inSlice(val) {
+			t.Errorf("Values should have the value %v", val)
+		}
+	}
+}
+
+func TestValues_Anonymous(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	s := Values(b)
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{"example", 123} {
+		if !inSlice(val) {
+			t.Errorf("Values should have the value %v", val)
+		}
+	}
+}
+
+func TestNames(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	s := Names(T)
+
+	if len(s) != 3 {
+		t.Errorf("Names should return a slice of len 3, got: %d", len(s))
+	}
+
+	inSlice := func(val string) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v, val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []string{"A", "B", "C"} {
+		if !inSlice(val) {
+			t.Errorf("Names should have the value %v", val)
+		}
+	}
+}
+
+func TestFields(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool
+	}{
+		A: "a-value",
+		B: 2,
+		C: true,
+	}
+
+	s := Fields(T)
+
+	if len(s) != 3 {
+		t.Errorf("Fields should return a slice of len 3, got: %d", len(s))
+	}
+
+	inSlice := func(val string) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v.Name(), val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []string{"A", "B", "C"} {
+		if !inSlice(val) {
+			t.Errorf("Fields should have the value %v", val)
+		}
+	}
+}
+
+func TestFields_OmitNested(t *testing.T) {
+	type A struct {
+		Name    string
+		Enabled bool
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A      A
+		C      int
+		Value  string `structs:"-"`
+		Number int
+	}
+	b := &B{A: a, C: 123}
+
+	s := Fields(b)
+
+	if len(s) != 3 {
+		t.Errorf("Fields should omit nested struct. Expecting 2 got: %d", len(s))
+	}
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v.Name(), val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{"A", "C"} {
+		if !inSlice(val) {
+			t.Errorf("Fields should have the value %v", val)
+		}
+	}
+}
+
+func TestFields_Anonymous(t *testing.T) {
+	type A struct {
+		Name string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	s := Fields(b)
+
+	inSlice := func(val interface{}) bool {
+		for _, v := range s {
+			if reflect.DeepEqual(v.Name(), val) {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, val := range []interface{}{"A", "C"} {
+		if !inSlice(val) {
+			t.Errorf("Fields should have the value %v", val)
+		}
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool `structs:"-"`
+		D []string
+	}{}
+
+	ok := IsZero(T)
+	if !ok {
+		t.Error("IsZero should return true because none of the fields are initialized.")
+	}
+
+	var X = struct {
+		A string
+		F *bool
+	}{
+		A: "a-value",
+	}
+
+	ok = IsZero(X)
+	if ok {
+		t.Error("IsZero should return false because A is initialized")
+	}
+
+	var Y = struct {
+		A string
+		B int
+	}{
+		A: "a-value",
+		B: 123,
+	}
+
+	ok = IsZero(Y)
+	if ok {
+		t.Error("IsZero should return false because A and B is initialized")
+	}
+}
+
+func TestIsZero_OmitNested(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A A `structs:",omitnested"`
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	ok := IsZero(b)
+	if ok {
+		t.Error("IsZero should return false because A, B and C are initialized")
+	}
+
+	aZero := A{}
+	bZero := &B{A: aZero}
+
+	ok = IsZero(bZero)
+	if !ok {
+		t.Error("IsZero should return true because neither A nor B is initialized")
+	}
+
+}
+
+func TestIsZero_Nested(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A A
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	ok := IsZero(b)
+	if ok {
+		t.Error("IsZero should return false because A, B and C are initialized")
+	}
+
+	aZero := A{}
+	bZero := &B{A: aZero}
+
+	ok = IsZero(bZero)
+	if !ok {
+		t.Error("IsZero should return true because neither A nor B is initialized")
+	}
+
+}
+
+func TestIsZero_Anonymous(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	ok := IsZero(b)
+	if ok {
+		t.Error("IsZero should return false because A, B and C are initialized")
+	}
+
+	aZero := A{}
+	bZero := &B{}
+	bZero.A = aZero
+
+	ok = IsZero(bZero)
+	if !ok {
+		t.Error("IsZero should return true because neither A nor B is initialized")
+	}
+}
+
+func TestHasZero(t *testing.T) {
+	var T = struct {
+		A string
+		B int
+		C bool `structs:"-"`
+		D []string
+	}{
+		A: "a-value",
+		B: 2,
+	}
+
+	ok := HasZero(T)
+	if !ok {
+		t.Error("HasZero should return true because A and B are initialized.")
+	}
+
+	var X = struct {
+		A string
+		F *bool
+	}{
+		A: "a-value",
+	}
+
+	ok = HasZero(X)
+	if !ok {
+		t.Error("HasZero should return true because A is initialized")
+	}
+
+	var Y = struct {
+		A string
+		B int
+	}{
+		A: "a-value",
+		B: 123,
+	}
+
+	ok = HasZero(Y)
+	if ok {
+		t.Error("HasZero should return false because A and B is initialized")
+	}
+}
+
+func TestHasZero_OmitNested(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A A `structs:",omitnested"`
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	// Because the Field A inside B is omitted  HasZero should return false
+	// because it will stop iterating deeper andnot going to lookup for D
+	ok := HasZero(b)
+	if ok {
+		t.Error("HasZero should return false because A and C are initialized")
+	}
+}
+
+func TestHasZero_Nested(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A A
+		C int
+	}
+	b := &B{A: a, C: 123}
+
+	ok := HasZero(b)
+	if !ok {
+		t.Error("HasZero should return true because D is not initialized")
+	}
+}
+
+func TestHasZero_Anonymous(t *testing.T) {
+	type A struct {
+		Name string
+		D    string
+	}
+	a := A{Name: "example"}
+
+	type B struct {
+		A
+		C int
+	}
+	b := &B{C: 123}
+	b.A = a
+
+	ok := HasZero(b)
+	if !ok {
+		t.Error("HasZero should return false because D is not initialized")
+	}
+}
+
+func TestName(t *testing.T) {
+	type Foo struct {
+		A string
+		B bool
+	}
+	f := &Foo{}
+
+	n := Name(f)
+	if n != "Foo" {
+		t.Errorf("Name should return Foo, got: %s", n)
+	}
+
+	unnamed := struct{ Name string }{Name: "Cihangir"}
+	m := Name(unnamed)
+	if m != "" {
+		t.Errorf("Name should return empty string for unnamed struct, got: %s", n)
+	}
+
+	defer func() {
+		err := recover()
+		if err == nil {
+			t.Error("Name should panic if a non struct is passed")
+		}
+	}()
+
+	Name([]string{})
+}
+
+func TestNestedNilPointer(t *testing.T) {
+	type Collar struct {
+		Engraving string
+	}
+
+	type Dog struct {
+		Name   string
+		Collar *Collar
+	}
+
+	type Person struct {
+		Name string
+		Dog  *Dog
+	}
+
+	person := &Person{
+		Name: "John",
+	}
+
+	personWithDog := &Person{
+		Name: "Ron",
+		Dog: &Dog{
+			Name: "Rover",
+		},
+	}
+
+	personWithDogWithCollar := &Person{
+		Name: "Kon",
+		Dog: &Dog{
+			Name: "Ruffles",
+			Collar: &Collar{
+				Engraving: "If lost, call Kon",
+			},
+		},
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Internal nil pointer should not panic")
+		}
+	}()
+
+	_ = Map(person)                  // Panics
+	_ = Map(personWithDog)           // Panics
+	_ = Map(personWithDogWithCollar) // Doesn't panic
+}
+
+func TestSetValueOnNestedField(t *testing.T) {
+	type Base struct {
+		ID int
+	}
+
+	type User struct {
+		Base
+		Name string
+	}
+
+	u := User{}
+	s := New(&u)
+	f := s.Field("Base").Field("ID")
+	err := f.Set(10)
+	if err != nil {
+		t.Errorf("Error %v", err)
+	}
+	if f.Value().(int) != 10 {
+		t.Errorf("Value should be equal to 10, got %v", f.Value())
+	}
+}
+
+type Person struct {
+	Name string
+	Age  int
+}
+
+func (p *Person) String() string {
+	return fmt.Sprintf("%s(%d)", p.Name, p.Age)
+}
+
+func TestTagWithStringOption(t *testing.T) {
+
+	type Address struct {
+		Country string  `json:"country"`
+		Person  *Person `json:"person,string"`
+	}
+
+	person := &Person{
+		Name: "John",
+		Age:  23,
+	}
+
+	address := &Address{
+		Country: "EU",
+		Person:  person,
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Internal nil pointer should not panic")
+		}
+	}()
+
+	s := New(address)
+
+	s.TagName = "json"
+	m := s.Map()
+
+	if m["person"] != person.String() {
+		t.Errorf("Value for field person should be %s, got: %s", person.String(), m["person"])
+	}
+
+	vs := s.Values()
+	if vs[1] != person.String() {
+		t.Errorf("Value for 2nd field (person) should be %T, got: %T", person.String(), vs[1])
+	}
+}
+
+type Animal struct {
+	Name string
+	Age  int
+}
+
+type Dog struct {
+	Animal *Animal `json:"animal,string"`
+}
+
+func TestNonStringerTagWithStringOption(t *testing.T) {
+	a := &Animal{
+		Name: "Fluff",
+		Age:  4,
+	}
+
+	d := &Dog{
+		Animal: a,
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Internal nil pointer should not panic")
+		}
+	}()
+
+	s := New(d)
+
+	s.TagName = "json"
+	m := s.Map()
+
+	if _, exists := m["animal"]; exists {
+		t.Errorf("Value for field Animal should not exist")
+	}
+}
+
+func TestMap_InterfaceValue(t *testing.T) {
+	type TestStruct struct {
+		A interface{}
+	}
+
+	expected := []byte("test value")
+
+	a := TestStruct{A: expected}
+	s := Map(a)
+	if !reflect.DeepEqual(s["A"], expected) {
+		t.Errorf("Value does not match expected: %q != %q", s["A"], expected)
+	}
+}
+
+func TestPointer2Pointer(t *testing.T) {
+	defer func() {
+		err := recover()
+		if err != nil {
+			fmt.Printf("err %+v\n", err)
+			t.Error("Internal nil pointer should not panic")
+		}
+	}()
+	a := &Animal{
+		Name: "Fluff",
+		Age:  4,
+	}
+	_ = Map(&a)
+
+	b := &a
+	_ = Map(&b)
+
+	c := &b
+	_ = Map(&c)
+}
+
+func TestMap_InterfaceTypeWithMapValue(t *testing.T) {
+	type A struct {
+		Name    string      `structs:"name"`
+		IP      string      `structs:"ip"`
+		Query   string      `structs:"query"`
+		Payload interface{} `structs:"payload"`
+	}
+
+	a := A{
+		Name:    "test",
+		IP:      "127.0.0.1",
+		Query:   "",
+		Payload: map[string]string{"test_param": "test_param"},
+	}
+
+	defer func() {
+		err := recover()
+		if err != nil {
+			t.Error("Converting Map with an interface{} type with map value should not panic")
+		}
+	}()
+
+	_ = Map(a)
+}

--- a/internal/structs/tags.go
+++ b/internal/structs/tags.go
@@ -1,0 +1,32 @@
+package structs
+
+import "strings"
+
+// tagOptions contains a slice of tag options
+type tagOptions []string
+
+// Has returns true if the given option is available in tagOptions
+func (t tagOptions) Has(opt string) bool {
+	for _, tagOpt := range t {
+		if tagOpt == opt {
+			return true
+		}
+	}
+
+	return false
+}
+
+// parseTag splits a struct field's tag into its name and a list of options
+// which comes after a name. A tag is in the form of: "name,option1,option2".
+// The name can be neglectected.
+func parseTag(tag string) (string, tagOptions) {
+	// tag is one of followings:
+	// ""
+	// "name"
+	// "name,opt"
+	// "name,opt,opt2"
+	// ",opt"
+
+	res := strings.Split(tag, ",")
+	return res[0], res[1:]
+}

--- a/internal/structs/tags_test.go
+++ b/internal/structs/tags_test.go
@@ -1,0 +1,46 @@
+package structs
+
+import "testing"
+
+func TestParseTag_Name(t *testing.T) {
+	tags := []struct {
+		tag string
+		has bool
+	}{
+		{"", false},
+		{"name", true},
+		{"name,opt", true},
+		{"name , opt, opt2", false}, // has a single whitespace
+		{", opt, opt2", false},
+	}
+
+	for _, tag := range tags {
+		name, _ := parseTag(tag.tag)
+
+		if (name != "name") && tag.has {
+			t.Errorf("Parse tag should return name: %#v", tag)
+		}
+	}
+}
+
+func TestParseTag_Opts(t *testing.T) {
+	tags := []struct {
+		opts string
+		has  bool
+	}{
+		{"name", false},
+		{"name,opt", true},
+		{"name , opt, opt2", false}, // has a single whitespace
+		{",opt, opt2", true},
+		{", opt3, opt4", false},
+	}
+
+	// search for "opt"
+	for _, tag := range tags {
+		_, opts := parseTag(tag.opts)
+
+		if opts.Has("opt") != tag.has {
+			t.Errorf("Tag opts should have opt: %#v", tag)
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spire",
-  "version": "2.1.1",
+  "version": "2.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Akkadius/spire.git"


### PR DESCRIPTION
Update logic for all saves has been rewritten to only update fields that have changed. This will also as a side effect resolve an issue where when values are set to zero, the object would not properly save.
