### PR TITLE
[Bug Fix] Fix Skill Mod Type opacity when using 1H Blunt

### DIFF
--- a/frontend/src/components/preview/EQItemCardPreview.vue
+++ b/frontend/src/components/preview/EQItemCardPreview.vue
@@ -221,7 +221,7 @@
     </div>
 
     <!-- Skill Mod Type -->
-    <div class="row" v-if="itemData['skillmodtype'] > 0 && itemData['skillmodvalue'] !== 0">
+    <div class="row" v-if="itemData['skillmodtype'] >= 0 && itemData['skillmodvalue'] !== 0">
       <div class="mt-3 col-12">
         <span style="font-weight: bold" class="pr-2">Skill Mod ({{ getSkillModSkill() }}) </span>
         +{{ itemData.skillmodvalue }}

--- a/frontend/src/views/items/ItemEditor.vue
+++ b/frontend/src/views/items/ItemEditor.vue
@@ -629,7 +629,7 @@
                       </div>
                       <div
                         v-b-tooltip.hover.v-dark.right :title="getFieldDescription(field.field)"
-                        class="col-4 m-0 p-0" :style="(item[field.field] <= 0 ? 'opacity: .5' : '')"
+                        class="col-4 m-0 p-0" :style="(((field.field != 'skillmodtype' && item[field.field] <= 0) || (field.field == 'skillmodtype' && item[field.field] < 0)) ? 'opacity: .5' : '')"
                       >
 
                         <b-form-input


### PR DESCRIPTION
# Notes
- Fixes issue where Skill Mod Type uses `0` for `1H Blunt` and `<= 0` makes this set its opacity to `0.5`.