### PR TITLE
[Config] Allow Spire Web to be configured

### DIFF
--- a/internal/desktop/web_boot_service.go
+++ b/internal/desktop/web_boot_service.go
@@ -2,6 +2,8 @@ package desktop
 
 import (
 	"fmt"
+	"github.com/Akkadius/spire/internal/env"
+	"github.com/Akkadius/spire/internal/eqemuserverconfig"
 	"github.com/Akkadius/spire/internal/http"
 	"github.com/sirupsen/logrus"
 	"log"
@@ -18,10 +20,19 @@ import (
 type WebBoot struct {
 	logger *logrus.Logger
 	server *http.Server
+	config *eqemuserverconfig.Config
 }
 
-func NewWebBoot(logger *logrus.Logger, server *http.Server) *WebBoot {
-	return &WebBoot{logger: logger, server: server}
+func NewWebBoot(
+	logger *logrus.Logger,
+	server *http.Server,
+	config *eqemuserverconfig.Config,
+) *WebBoot {
+	return &WebBoot{
+		logger: logger,
+		server: server,
+		config: config,
+	}
 }
 
 func (c *WebBoot) Boot() {
@@ -34,6 +45,16 @@ func (c *WebBoot) Boot() {
 			port = i
 			break
 		}
+	}
+
+	// if we have a port set in the config, use that instead
+	if c.config.Get().Spire.HttpPort != 0 {
+		port = c.config.Get().Spire.HttpPort
+	}
+
+	// if we have a port set in the environment, use that instead
+	if len(os.Getenv("SPIRE_HTTP_PORT")) > 0 {
+		port = env.GetInt("SPIRE_HTTP_PORT", "3000")
 	}
 
 	if port == 0 {

--- a/internal/eqemuserverconfig/eqemu_server_config.go
+++ b/internal/eqemuserverconfig/eqemu_server_config.go
@@ -122,6 +122,7 @@ type EQEmuConfigJson struct {
 	} `json:"web-admin,omitempty"`
 	Spire struct {
 		EncryptionKey string `json:"encryption_key,omitempty"`
+		HttpPort      int    `json:"http_port,omitempty"`
 	} `json:"spire,omitempty"`
 }
 


### PR DESCRIPTION
This PR allows Spire's HTTP server to be additionally configured in two more places.

Currently, you can run

```bash
./spire http:serve --port=x
```

To run Spire's web services on a specific port. This does not go through the traditional booting mechanisms when Spire is ran on a fully installed server. The default mechanism also chooses a random range 8090 through 8099 which is commonly used on desktop machines and also used when Spire is ran with no arguments

This PR allows you to be able to specify a default port through 

* **eqemu_config.json** @ **spire.http_port** if it exists
* Environment variable `SPIRE_HTTP_PORT` if it exists

For example

```bash
SPIRE_HTTP_PORT=3001 go run main.go
```

Results in

```
... truncated
 A rich, portable server editing and development toolkit for EverQuest Emulator servers

⇨ http server started on [::]:3001
```