### PR TITLE
[Updater] Exit immediately when no terminal is present

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 func main() {
 	// self update service
 	if len(os.Args) == 1 {
-		updater.NewUpdaterService(packageJson).CheckForUpdates()
+		updater.NewService(packageJson).CheckForUpdates()
 	}
 
 	// default


### PR DESCRIPTION
When a user updates Spire, normally the user is prompted to "Press any key to exit" and manually restart Spire.

Under the circumstances of automation, running Spire headlessly with orchestration tools, supervisors etc. we need Spire to simply restart after update silently only for the supervisor process to automatically spin up Spire after upgrading. Hanging while waiting for user input will just keep Spire hanging indefinitely after launching