### PR TITLE
[Assets] Improve asset downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [3.1.0] 4/29/2023
+
+* Improvements to how Spire acquires static assets
+
 ## [3.0.8] 4/28/2023
 
 * Spire will now exit immediately after updating if no terminal is attached [#114](https://github.com/Akkadius/spire/pull/114)

--- a/boot/wire_gen.go
+++ b/boot/wire_gen.go
@@ -323,7 +323,7 @@ func InitializeApplication() (App, error) {
 	permissionsMiddleware := middleware.NewPermissionsMiddleware(databaseResolver, logger, cache, service)
 	requestLogMiddleware := middleware.NewRequestLogMiddleware(client)
 	localUserAuthMiddleware := middleware.NewLocalUserAuthMiddleware(databaseResolver, logger, cache, settings, init)
-	spireAssets := assets.NewSpireAssets(logger, cache, githubSourceDownloader)
+	spireAssets := assets.NewSpireAssets(logger, pathManagement)
 	router := NewRouter(bootAppControllerGroups, bootCrudControllers, userContextMiddleware, readOnlyMiddleware, permissionsMiddleware, requestLogMiddleware, localUserAuthMiddleware, spireAssets)
 	server := http.NewServer(logger, router, processManagement)
 	httpServeCommand := cmd.NewHttpServeCommand(logger, server)

--- a/internal/assets/spire_assets.go
+++ b/internal/assets/spire_assets.go
@@ -1,84 +1,62 @@
 package assets
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/Akkadius/spire/internal/download"
 	"github.com/Akkadius/spire/internal/env"
-	"github.com/Akkadius/spire/internal/github"
 	appmiddleware "github.com/Akkadius/spire/internal/http/middleware"
+	"github.com/Akkadius/spire/internal/pathmgmt"
+	"github.com/Akkadius/spire/internal/unzip"
 	"github.com/labstack/echo/v4"
-	gocache "github.com/patrickmn/go-cache"
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type SpireAssets struct {
-	logger     *logrus.Logger
-	cache      *gocache.Cache
-	downloader *github.GithubSourceDownloader
+	logger      *logrus.Logger
+	pathmanager *pathmgmt.PathManagement
 }
-
-const (
-	organization = "Akkadius"
-	repository   = "eq-asset-preview"
-	version      = 1
-)
 
 func NewSpireAssets(
 	logger *logrus.Logger,
-	cache *gocache.Cache,
-	downloader *github.GithubSourceDownloader,
+	pathmanager *pathmgmt.PathManagement,
 ) *SpireAssets {
 	return &SpireAssets{
-		logger:     logger,
-		cache:      cache,
-		downloader: downloader,
+		logger:      logger,
+		pathmanager: pathmanager,
 	}
 }
 
-func (a SpireAssets) ServeStatic() echo.MiddlewareFunc {
-	// cleanup old versions
-	for i := 1; i < version; i++ {
-		oldPath := filepath.Join(a.downloader.GetSourceRoot(), fmt.Sprintf("%v-v%v", repository, i))
-		fmt.Printf("Deleting old assets [%v]\n", oldPath)
-		err := os.RemoveAll(oldPath)
-		if err != nil {
-			a.logger.Fatal(err)
-		}
-	}
+const (
+	assetRepo = "Akkadius/eq-asset-preview"
+)
 
-	zippedPath := a.getZippedPath()
-	if !a.AssetsExists() && len(zippedPath) == 0 {
-		downloader := github.NewGithubSourceDownloader(a.logger, a.cache)
-		branch := fmt.Sprintf("v%v", version)
-		downloader.SourceToUserCacheDir(true)
-		downloader.SetReadFiles(false)
-		r := downloader.Source(organization, repository, branch, false)
-		if len(r.ZippedPath) > 0 {
-			zippedPath = r.ZippedPath
-		}
-	}
+func (a SpireAssets) ServeStatic() echo.MiddlewareFunc {
+	// get cachedir
+	cachedir := filepath.Join(a.getCacheDir(), "spire", "assets")
+
+	// check for assets
+	a.checkForAssets()
 
 	// in development, perform a symlink between the downloaded assets and the frontend public directory
 	// the reason for this is that in development we run the Vue development web server
 	// and assets resolve relative to the webserver running assets there - so they need
 	// to be available via the FE web dev server
 	// this is a convenience
-	if len(zippedPath) > 0 {
+	if len(cachedir) > 0 {
 		if env.IsAppEnvDev() {
 			symlinkTarget := filepath.Join("./frontend/public/eq-asset-preview-master")
 
-			// remove link if exists
-			if _, err := os.Lstat(symlinkTarget); err == nil {
-				if err := os.Remove(symlinkTarget); err != nil {
-					a.logger.Errorf("failed to unlink: %+v", err)
-				}
-			}
+			// always remove the link if it is there
+			_ = os.Remove(symlinkTarget)
 
 			// relink
-			err := os.Symlink(a.getZippedPath(), symlinkTarget)
+			err := os.Symlink(cachedir, symlinkTarget)
 			if err != nil {
 				a.logger.Fatal(err)
 			}
@@ -89,29 +67,115 @@ func (a SpireAssets) ServeStatic() echo.MiddlewareFunc {
 	return appmiddleware.StaticAsset(appmiddleware.StaticConfig{
 		Root:        "/",
 		StripPrefix: string(filepath.Separator) + "eq-asset-preview-master",
-		Filesystem:  http.Dir(zippedPath),
+		Filesystem:  http.Dir(cachedir),
 	})
 }
 
-func (a SpireAssets) AssetsExists() bool {
-	if _, err := os.Stat(a.getRepoDir()); err == nil {
-		return true
+func (a SpireAssets) downloadAssets(cachedir string) {
+	a.logger.Infof("Downloading [eq-asset-preview] latest release\n")
+
+	// zip file path
+	dumpZip := filepath.Join(os.TempDir(), "/build.zip")
+
+	// download the zip file
+	err := download.WithProgress(
+		dumpZip,
+		fmt.Sprintf("https://github.com/%v/releases/latest/download/build.zip", assetRepo),
+	)
+	if err != nil {
+		a.logger.Fatalln(err)
 	}
 
-	return false
-}
-
-func (a SpireAssets) getZippedPath() string {
-	repoDir := a.getRepoDir()
-	zippedPath := ""
-	files, _ := ioutil.ReadDir(repoDir)
-	if len(files) > 0 {
-		zippedPath = filepath.Join(repoDir, files[0].Name())
+	// unzip the file
+	a.logger.Infof("Downloaded zip to [%v]\n", dumpZip)
+	err = unzip.New(dumpZip, cachedir).Extract()
+	if err != nil {
+		a.logger.Fatalf("could not extract zip: %v", err)
 	}
 
-	return zippedPath
+	// remove the zip file
+	err = os.Remove(dumpZip)
+	if err != nil {
+		a.logger.Fatalf("could not remove zip: %v", err)
+	}
 }
 
-func (a SpireAssets) getRepoDir() string {
-	return filepath.Join(a.downloader.GetSourceRoot(), fmt.Sprintf("%v-v%v", repository, version))
+func (a SpireAssets) getCacheDir() string {
+	userDir, err := os.UserCacheDir()
+	if err != nil {
+		a.logger.Error(err)
+	}
+	if len(userDir) > 0 {
+		return userDir
+	}
+
+	return os.TempDir()
+}
+
+func (a SpireAssets) checkForAssets() {
+	cachedir := filepath.Join(a.getCacheDir(), "spire", "assets")
+
+	// check if cachedir exists
+	if _, err := os.Stat(cachedir); os.IsNotExist(err) {
+		a.downloadAssets(cachedir)
+	}
+
+	// GitHub release struct
+	type GitHubRelease struct {
+		TagName string `json:"tag_name"`
+	}
+
+	// get latest release version
+	resp, err := http.Get(fmt.Sprintf("https://api.github.com/repos/%v/releases/latest", assetRepo))
+	if err != nil {
+		a.logger.Info("could not get latest release version for [%v] %v", assetRepo, err)
+	}
+
+	defer resp.Body.Close()
+
+	// check if response is 200
+	if err == nil {
+		// read response body
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			a.logger.Fatalf("could not read response body: %v", err)
+		}
+
+		// bind body to struct
+		var release GitHubRelease
+		err = json.Unmarshal(body, &release)
+		if err != nil {
+			a.logger.Fatalf("could not unmarshal response body: %v", err)
+		}
+
+		type PackageJson struct {
+			Version string `json:"version"`
+		}
+
+		// get current version from package.json
+		file := filepath.Join(cachedir, "package.json")
+
+		// read file package.json contents into PackageJson struct
+		packageJson, err := os.ReadFile(file)
+		if err != nil {
+			a.logger.Fatalf("could not read PackageJson file: %v", err)
+		}
+
+		// bind package.json to struct
+		var packageJsonStruct PackageJson
+		err = json.Unmarshal(packageJson, &packageJsonStruct)
+		if err != nil {
+			a.logger.Fatalf("could not unmarshal package.json: %v", err)
+		}
+
+		// check if current version is the same as the latest release version
+		remoteRelease := strings.ReplaceAll(release.TagName, "v", "")
+		if len(remoteRelease) > 0 && packageJsonStruct.Version != remoteRelease {
+			a.logger.Infof(
+				"New version available, downloading [eq-asset-preview] release [%v]\n",
+				release.TagName,
+			)
+			a.downloadAssets(cachedir)
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spire",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Akkadius/spire.git"


### PR DESCRIPTION
Spire uses downloads static assets for things like icons, models, video previews etc. This moves static assets to now be versioned and downloaded via release system. This will improve download times, versioning and reliability

```
INFO[2023-04-29 01:14:12] Downloading [eq-asset-preview] release       
INFO[2023-04-29 01:14:12] New version available, downloading [eq-asset-preview] release [v1.0.1] 

   █░░ █▀█ ▄▀█ █▀▄ █ █▄░█ █▀▀         █▀█ █░░ █▀▀ ▄▀█ █▀ █▀▀   █░█░█ ▄▀█ █ ▀█▀     
   █▄▄ █▄█ █▀█ █▄▀ █ █░▀█ █▄█ ▄ ▄ ▄   █▀▀ █▄▄ ██▄ █▀█ ▄█ ██▄   ▀▄▀▄▀ █▀█ █ ░█░ ▄ ▄ ▄

[Downloading] URL [https://github.com/Akkadius/eq-asset-preview/releases/latest/download/build.zip]
[Downloading] To [/tmp/build.zip]

[Downloading] 100% |██████████████████████████████| (64 MB/s)         

INFO[2023-04-29 01:14:18] Downloaded zip to [/tmp/build.zip]           
[Zip] Extraction of [/tmp/build.zip] started!
[Zip] Extracted (5858) files in [/tmp/build.zip] to [/home/eqemu/.cache/spire/assets]!
```