### PR TITLE
[Cleanup] Fix issue where various methods show curly in output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/labstack/gommon v0.4.0
-	github.com/mattn/go-isatty v0.0.16
 	github.com/mholt/archiver/v4 v4.0.0-alpha.7
 	github.com/muesli/termenv v0.13.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -75,6 +74,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/k0kubun/pp/v3 v3.2.0
 	github.com/labstack/echo/v4 v4.9.0
 	github.com/labstack/gommon v0.4.0
+	github.com/mattn/go-isatty v0.0.16
 	github.com/mholt/archiver/v4 v4.0.0-alpha.7
 	github.com/muesli/termenv v0.13.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
@@ -74,7 +75,6 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
-	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/nwaples/rardecode/v2 v2.0.0-beta.2 // indirect

--- a/internal/questapi/file_parse_perl_methods.go
+++ b/internal/questapi/file_parse_perl_methods.go
@@ -59,6 +59,10 @@ func (c *ParseService) parsePerlMethods(contents string, perlMethods map[string]
 			l = strings.ReplaceAll(l, "perl::scalar", "scalar")
 		}
 
+		if strings.Contains(l, " {") {
+			l = strings.ReplaceAll(l, " {", "")
+		}
+
 		lineSplit := strings.Split(l, " ")
 		if len(lineSplit) > 1 && len(lineSplit[1]) > 5 {
 			methodIdentifier := lineSplit[1][:5]


### PR DESCRIPTION
# Notes
- Various methods were showing ` {` after their parameters since they were on the same line unlike most other methods.

# Before
![image](https://user-images.githubusercontent.com/89047260/236712139-c9e13105-aeed-4819-9673-4c0e461bd782.png)

# After
![image](https://user-images.githubusercontent.com/89047260/236712191-e4afdcae-05d0-446c-87da-f32c31a5afd0.png)

