### PR TITLE
[Bug Fix/Feature] Counter Avoid Damage and missing special abilities

### DIFF
--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -643,6 +643,7 @@ export default {
         { name: "Immune to Client Aggro", ability: 49 },
         { name: "Immune to NPC Aggro", ability: 50 },
         { name: "Immune to Memory Fades", ability: 52 },
+        { name: "Immune to Open", ability: 53 },
       ]
     }
   },

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -21,8 +21,8 @@
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[1][1]" value="" v-b-tooltip.hover title="HP % before summon (default: 97)"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[1][1]" v-b-tooltip.hover title="HP % before summon (default: 97)"
           >
         </td>
       </tr>
@@ -41,21 +41,21 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[2][0]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[2][0]" placeholder="0"
             v-b-tooltip.hover title="HP % to Enrage (rule NPC:StartEnrageValue)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[2][1]" value="" placeholder="10000" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[2][1]" placeholder="10000" v-b-tooltip.hover
             title="Duration (ms) (10000)"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[2][2]" value="" placeholder="360000" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[2][2]" placeholder="360000" v-b-tooltip.hover
             title="Cooldown (ms) (360000)"
           >
         </td>
@@ -75,44 +75,44 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][0]" value="" placeholder="20" v-b-tooltip.hover title="Proc chance"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][0]" placeholder="20" v-b-tooltip.hover title="Proc chance"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][1]" value="" placeholder="Combat:MaxRampageTargets"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][1]" placeholder="Combat:MaxRampageTargets"
             v-b-tooltip.hover title="Rampage target count (default: rule Combat:MaxRampageTargets)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][2]" value="" placeholder="0" v-b-tooltip.hover title="Flat damage to add"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][2]" placeholder="0" v-b-tooltip.hover title="Flat damage to add"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][3]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][3]" placeholder="0"
             v-b-tooltip.hover title="Ignore % armor for this attack (0) "
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][4]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][4]" placeholder="0"
             v-b-tooltip.hover title="Ignore flat armor for this attack (0)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][5]" value="" placeholder="100" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][5]" placeholder="100" v-b-tooltip.hover
             title="% NPC Crit against (100)"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[3][6]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[3][6]" placeholder="0"
             v-b-tooltip.hover title="Flat crit bonus on top of npc's natual crit that can go toward this attack"
           >
         </td>
@@ -132,15 +132,15 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][0]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][0]" placeholder="0" v-b-tooltip.hover
             title="Rampage target count (1)"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][1]" value="" placeholder="100"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][1]" placeholder="100"
             v-b-tooltip.hover title="% of normal attack damage (100)"
           ></td>
         <td>
@@ -148,7 +148,7 @@
             type="text"
             @change="calculateSpecialAbilities"
             class="ability_check_sub form-control"
-            style=""
+
             v-model="abilityParams[4][2]"
             value=""
             placeholder="0"
@@ -158,27 +158,27 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][3]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][3]" placeholder="0"
             v-b-tooltip.hover title="Ignore % armor for this attack (0) "
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][4]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][4]" placeholder="0"
             v-b-tooltip.hover title="Ignore flat armor for this attack (0)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][5]" value="" placeholder="100" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][5]" placeholder="100" v-b-tooltip.hover
             title="% NPC Crit against (100)"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[4][6]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[4][6]" placeholder="0"
             v-b-tooltip.hover title="Flat crit bonus on top of npc's natual crit that can go toward this attack"
           >
         </td>
@@ -198,44 +198,44 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][0]" value="" placeholder="Combat:MaxFlurryHits"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][0]" placeholder="Combat:MaxFlurryHits"
             v-b-tooltip.hover title="Flurry attack count"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][1]" value="" placeholder="100"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][1]" placeholder="100"
             v-b-tooltip.hover title="Percent of a normal attack damage to deal"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][2]" value="" placeholder="0" v-b-tooltip.hover title="Flat damage bonus"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][2]" placeholder="0" v-b-tooltip.hover title="Flat damage bonus"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][3]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][3]" placeholder="0"
             v-b-tooltip.hover title="Ignore % armor for this attack (0) "
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][4]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][4]" placeholder="0"
             v-b-tooltip.hover title="Ignore flat armor for this attack (0)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][5]" value="" placeholder="100"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][5]" placeholder="100"
             v-b-tooltip.hover title="% NPC Crit against attack (100)"
           ></td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[5][6]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[5][6]" placeholder="0"
             v-b-tooltip.hover title="Flat crit bonus on top of npc's natual crit that can go toward this attack"
           >
         </td>
@@ -255,35 +255,35 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[11][0]" value="" placeholder="0" v-b-tooltip.hover title="Number of Attacks"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[11][0]" placeholder="0" v-b-tooltip.hover title="Number of Attacks"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[11][1]" value="" placeholder="250" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[11][1]" placeholder="250" v-b-tooltip.hover
             title="Max Range (default: 250)"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[11][2]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[11][2]" placeholder="0" v-b-tooltip.hover
             title="Percent Hit Chance Modifier"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[11][3]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[11][3]" placeholder="0" v-b-tooltip.hover
             title="Percent Damage Modifier"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[11][4]" value="" placeholder="25"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[11][4]" placeholder="25"
             v-b-tooltip.hover title="Min Range (default: RuleI(Combat, MinRangedAttackDist) = 25)"
           ></td>
       </tr>
@@ -302,8 +302,8 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[29][0]" value="" placeholder="75" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[29][0]" placeholder="75" v-b-tooltip.hover
             title="Aggro modifier on non-tanks"
           >
         </td>
@@ -323,8 +323,8 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[32][0]" value="" placeholder="0" v-b-tooltip.hover title="Range"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[32][0]" placeholder="0" v-b-tooltip.hover title="Range"
           ></td>
       </tr>
       </tbody>
@@ -342,8 +342,8 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[33][0]" value="" placeholder="0" v-b-tooltip.hover title="Aggo Range"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[33][0]" placeholder="0" v-b-tooltip.hover title="Aggo Range"
           ></td>
       </tr>
       </tbody>
@@ -361,15 +361,15 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[37][0]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[37][0]" placeholder="0" v-b-tooltip.hover
             title="Percent NPC will flee at"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[37][1]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[37][1]" placeholder="0" v-b-tooltip.hover
             title="Percent chance to flee"
           ></td>
       </tr>
@@ -388,20 +388,20 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[40][0]" value="" placeholder="0" v-b-tooltip.hover title="Max Chase Distance"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[40][0]" placeholder="0" v-b-tooltip.hover title="Max Chase Distance"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[40][1]" value="" placeholder="0" v-b-tooltip.hover title="Min Chase Distance"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[40][1]" placeholder="0" v-b-tooltip.hover title="Min Chase Distance"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[40][2]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[40][2]" placeholder="0"
             v-b-tooltip.hover title="Ignore line of sight check for chasing"
           ></td>
       </tr>
@@ -420,8 +420,8 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[41][0]" value="" placeholder="1"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[41][0]" placeholder="1"
             v-b-tooltip.hover
             title="Allows an NPC the opportunity to take aggro over a client if in melee range"
           >
@@ -442,8 +442,8 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[43][0]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[43][0]" placeholder="0"
             v-b-tooltip.hover
             title="Set an innate resist different to be applied to all spells cast by this NPC (stacks with a spells regular resist difference)."
           >
@@ -466,36 +466,36 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][0]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[44][0]" placeholder="0"
             v-b-tooltip.hover title="% Reduction to avoid melee via Riposte, Parry, Block, and Dodge"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][1]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[44][1]" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Riposte"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][2]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[44][2]" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Block"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][3]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[44][3]" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Parry"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][4]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[44][4]" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Dodge"
           >
         </td>
@@ -513,36 +513,36 @@
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[51][0]" value="" placeholder="0"
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[51][0]" placeholder="0"
             v-b-tooltip.hover title="% Addition to avoid melee via Riposte, Parry, Block, and Dodge"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[51][1]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[51][1]"placeholder="0" v-b-tooltip.hover
             title="% Addition to Riposte"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[51][2]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[51][2]" placeholder="0" v-b-tooltip.hover
             title="% Addition to Parry"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[51][3]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[51][3]" placeholder="0" v-b-tooltip.hover
             title="% Addition to Block"
           >
         </td>
         <td>
           <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[51][4]" value="" placeholder="0" v-b-tooltip.hover
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control"
+            v-model="abilityParams[51][4]" placeholder="0" v-b-tooltip.hover
             title="% Addition to Dodge"
           >
         </td>

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -468,7 +468,7 @@
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][0]" value="" placeholder="0"
-            v-b-tooltip.hover title="% Chance to avoid melee via Riposte, Parry, Block, or Dodge"
+            v-b-tooltip.hover title="% Chance to avoid melee via Riposte, Parry, Block, and Dodge"
           >
         </td>
         <td>

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -469,38 +469,33 @@
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][0]" value="" placeholder="0"
             v-b-tooltip.hover title="chance to avoid melee via dodge/parray/riposte/block skills "
-          ></td>
+          >
+        </td>
         <td>
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][1]" value="" placeholder="0-100" v-b-tooltip.hover
-            title="Avoidance % (0-100)"
+            v-model="abilityParams[44][1]" value="" placeholder="0" v-b-tooltip.hover
+            title="% Reduction to Riposte"
           >
         </td>
         <td>
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][2]" value="" placeholder="0" v-b-tooltip.hover
-            title="% Reduction to Riposte"
-          ></td>
-        <td>
-          <input
-            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][3]" value="" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Parry"
           >
         </td>
         <td>
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][4]" value="" placeholder="0" v-b-tooltip.hover
+            v-model="abilityParams[44][3]" value="" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Block"
           >
         </td>
         <td>
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
-            v-model="abilityParams[44][5]" value="" placeholder="0" v-b-tooltip.hover
+            v-model="abilityParams[44][4]" value="" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Dodge"
           >
         </td>

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -148,7 +148,6 @@
             type="text"
             @change="calculateSpecialAbilities"
             class="ability_check_sub form-control"
-
             v-model="abilityParams[4][2]"
             value=""
             placeholder="0"

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -468,7 +468,7 @@
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][0]" value="" placeholder="0"
-            v-b-tooltip.hover title="chance to avoid melee via dodge/parray/riposte/block skills "
+            v-b-tooltip.hover title="% Chance to avoid melee via Riposte, Parry, Block, or Dodge"
           >
         </td>
         <td>

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -468,7 +468,7 @@
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][0]" value="" placeholder="0"
-            v-b-tooltip.hover title="% Chance to avoid melee via Riposte, Parry, Block, and Dodge"
+            v-b-tooltip.hover title="% Reduction to avoid melee via Riposte, Parry, Block, and Dodge"
           >
         </td>
         <td>
@@ -497,6 +497,53 @@
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][4]" value="" placeholder="0" v-b-tooltip.hover
             title="% Reduction to Dodge"
+          >
+        </td>
+      </tr>
+      <tr>
+        <td class="ability-label-top">Modify Avoid Damage</td>
+        <td style="width:50px; text-align:center">
+
+          <eq-checkbox
+            class="d-inline-block"
+            v-model.number="ability[51]"
+            @input="calculateSpecialAbilities"
+          />
+
+        </td>
+        <td>
+          <input
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
+            v-model="abilityParams[51][0]" value="" placeholder="0"
+            v-b-tooltip.hover title="% Addition to avoid melee via Riposte, Parry, Block, and Dodge"
+          >
+        </td>
+        <td>
+          <input
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
+            v-model="abilityParams[51][1]" value="" placeholder="0" v-b-tooltip.hover
+            title="% Addition to Riposte"
+          >
+        </td>
+        <td>
+          <input
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
+            v-model="abilityParams[51][2]" value="" placeholder="0" v-b-tooltip.hover
+            title="% Addition to Parry"
+          >
+        </td>
+        <td>
+          <input
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
+            v-model="abilityParams[51][3]" value="" placeholder="0" v-b-tooltip.hover
+            title="% Addition to Block"
+          >
+        </td>
+        <td>
+          <input
+            type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
+            v-model="abilityParams[51][4]" value="" placeholder="0" v-b-tooltip.hover
+            title="% Addition to Dodge"
           >
         </td>
       </tr>
@@ -589,6 +636,13 @@ export default {
         { name: "Allow Beneficial", ability: 38 },
         { name: "Disable Melee", ability: 39 },
         { name: "Ignore Root Aggro", ability: 42 },
+        { name: "Proximity Aggro", ability: 45 },
+        { name: "Immune to Ranged Attacks", ability: 46 },
+        { name: "Immune to Client Damage", ability: 47 },
+        { name: "Immune to NPC Damage", ability: 48 },
+        { name: "Immune to Client Aggro", ability: 49 },
+        { name: "Immune to NPC Aggro", ability: 50 },
+        { name: "Immune to Memory Fades", ability: 52 },
       ]
     }
   },

--- a/frontend/src/components/tools/NpcSpecialAbilities.vue
+++ b/frontend/src/components/tools/NpcSpecialAbilities.vue
@@ -482,14 +482,14 @@
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][2]" value="" placeholder="0" v-b-tooltip.hover
-            title="% Reduction to Parry"
+            title="% Reduction to Block"
           >
         </td>
         <td>
           <input
             type="text" @change="calculateSpecialAbilities" class="ability_check_sub form-control" style=""
             v-model="abilityParams[44][3]" value="" placeholder="0" v-b-tooltip.hover
-            title="% Reduction to Block"
+            title="% Reduction to Parry"
           >
         </td>
         <td>


### PR DESCRIPTION
# Notes
- There are only 5 parameters for Counter Avoid Damage (44), not 6 and parameters were out of order.
- Add missing special abilities past 44 (45-53).

# Images
![image](https://github.com/Akkadius/spire/assets/89047260/469aba90-ddc2-4413-8bd6-00b4f2942620)
![image](https://github.com/Akkadius/spire/assets/89047260/1c9f4b9e-bd68-4ed5-91fe-01cc5af7b28c)