### PR TITLE
[Bug Fix] Fix Event Parsing in Perl/Lua

### DIFF
--- a/frontend/src/views/quest-api-explorer/QuestApiExplorer.vue
+++ b/frontend/src/views/quest-api-explorer/QuestApiExplorer.vue
@@ -733,8 +733,10 @@ export default {
             return
           }
 
-          let text = "[" + option.entity_type + "] " + option.event_identifier;
-          options.push({value: option.entity_type + '-' + option.event_identifier, text: text})
+          if (option.event_identifier != "") {
+            let text = "[" + option.entity_type + "] " + option.event_identifier;
+            options.push({value: option.entity_type + '-' + option.event_identifier, text: text})
+          }
         })
         this.eventOptions   = options
         this.eventSelection = null

--- a/internal/questapi/file_parse_lua_events.go
+++ b/internal/questapi/file_parse_lua_events.go
@@ -232,39 +232,47 @@ func (c *ParseService) parseLuaEvents(files map[string]string) []LuaEvent {
 							eventType := eventTypeSplit[0]
 							eventArgs := eventTypeSplit[1]
 							eventArgsSplit := strings.Split(eventArgs, ",")
-							// grep: EVENT_LEVEL_UP, this, "", 0);
-							// grab EVENT_LEVEL_UP
-							if len(eventArgsSplit) > 0 {
-								event := strings.TrimSpace(eventArgsSplit[0])
+							var eventTypes = []string{eventType}
 
-								// make sure the event doesn't already exist
-								eventExists := false
-								for _, luaEvent := range luaEvents {
-									if luaEvent.EventName == event && luaEvent.EntityType == eventType {
-										eventExists = true
-										break
-									}
-								}
+							if isSpecialEventType(eventType) {
+								eventTypes = getSpecialEventTypes(eventType)
+							}
 
-								// if event doesn't exist we need to map the EVENT_NAME to a script event_name(e)
-								// since they are not usually 1:1
-								if !eventExists {
-									identifier := ""
-									for _, mapping := range luaEventMappings {
-										if mapping.Event == event {
-											identifier = mapping.ScriptEventIdentifier
+							for _, finalEventType := range eventTypes {
+								// grep: EVENT_LEVEL_UP, this, "", 0);
+								// grab EVENT_LEVEL_UP
+								if len(eventArgsSplit) > 0 {
+									event := strings.TrimSpace(eventArgsSplit[0])
+
+									// make sure the event doesn't already exist
+									eventExists := false
+									for _, luaEvent := range luaEvents {
+										if luaEvent.EventName == event && luaEvent.EntityType == finalEventType {
+											eventExists = true
+											break
 										}
 									}
 
-									if len(identifier) > 0 {
-										e := LuaEvent{
-											EntityType:      eventType,
-											EventName:       event,
-											EventIdentifier: "event_" + identifier,
-											EventVars:       []string{},
+									// if event doesn't exist we need to map the EVENT_NAME to a script event_name(e)
+									// since they are not usually 1:1
+									if !eventExists {
+										identifier := ""
+										for _, mapping := range luaEventMappings {
+											if mapping.Event == event {
+												identifier = mapping.ScriptEventIdentifier
+											}
 										}
 
-										luaEvents = append(luaEvents, e)
+										if len(identifier) > 0 {
+											e := LuaEvent{
+												EntityType:      finalEventType,
+												EventName:       event,
+												EventIdentifier: "event_" + identifier,
+												EventVars:       []string{},
+											}
+
+											luaEvents = append(luaEvents, e)
+										}
 									}
 								}
 							}

--- a/internal/questapi/file_parse_perl_events.go
+++ b/internal/questapi/file_parse_perl_events.go
@@ -102,16 +102,24 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 							}
 						}
 
+						var eventTypes = []string{entity}
+
 						if entity == "Encounter" {
 							continue
 						}
 
-						eventEntityMappings = append(
-							eventEntityMappings, PerlEventEntityMapping{
-								Entity: entity,
-								Event:  event,
-							},
-						)
+						if isSpecialEventType(entity) {
+							eventTypes = getSpecialEventTypes(entity)
+						}
+
+						for _, eventType := range eventTypes {
+							eventEntityMappings = append(
+								eventEntityMappings, PerlEventEntityMapping{
+									Entity: eventType,
+									Event:  event,
+								},
+							)
+						}
 					}
 				}
 			}
@@ -218,70 +226,79 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 						// grep: Player(EVENT_LEVEL_UP, this, "", 0);
 						if len(eventTypeSplit) > 0 {
 							eventType := eventTypeSplit[0]
+							var eventTypes = []string{eventType}
 
 							if eventType == "Encounter" {
 								continue
+							}
+
+							if isSpecialEventType(eventType) {
+								eventTypes = getSpecialEventTypes(eventType)
 							}
 
 							eventArgs := eventTypeSplit[1]
 							eventArgsSplit := strings.Split(eventArgs, ",")
 							// grep: EVENT_LEVEL_UP, this, "", 0);
 							// grab EVENT_LEVEL_UP
-							if len(eventArgsSplit) > 0 {
-								event := strings.TrimSpace(eventArgsSplit[0])
+							for _, eventSubtype := range eventTypes {
+								if len(eventArgsSplit) > 0 {
+									event := strings.TrimSpace(eventArgsSplit[0])
 
-								// make sure the event doesn't already exist
-								eventExists := false
-								for _, perlEvent := range perlEvents {
-									if perlEvent.EventName == event && perlEvent.EntityType == eventType {
-										eventExists = true
-										break
-									}
-								}
+									// make sure the event doesn't already exist
 
-								// if event doesn't exist we need to map the EVENT_NAME to a script event_name(e)
-								// since they are not usually 1:1
-								if !eventExists {
-
-									// get the perl script-used event name if exists
-									// @example source: EVENT_TRADE perl usage: EVENT_ITEM
-									finalEvent := event
-									eventIndex := indexOf(event, eventCodes)
-									if eventIndex >= 0 {
-										if len(perlEventCodes) > eventIndex {
-											finalEvent = perlEventCodes[eventIndex]
-										}
-									}
-
-									if finalEvent == "evt.event_id" {
-										continue
-									}
-
-									// remove events that aren't all upper (for perl)
-									if !IsUpper(event) {
-										continue
-									}
-
-									// remove duplicates from results
-									hasEvent := false
-									for _, p := range perlEvents {
-										if p.EventIdentifier == finalEvent && p.EntityType == eventType {
-											hasEvent = true
+									eventExists := false
+									for _, perlEvent := range perlEvents {
+										if perlEvent.EventName == event && perlEvent.EntityType == eventSubtype {
+											eventExists = true
 											break
 										}
 									}
-									if hasEvent {
-										continue
-									}
 
-									perlEvents = append(
-										perlEvents, PerlEvent{
-											EntityType:      eventType,
-											EventName:       event,
-											EventIdentifier: finalEvent,
-											EventVars:       []string{},
-										},
-									)
+									// if event doesn't exist we need to map the EVENT_NAME to a script event_name(e)
+									// since they are not usually 1:1
+									if !eventExists {
+
+										// get the perl script-used event name if exists
+										// @example source: EVENT_TRADE perl usage: EVENT_ITEM
+										finalEvent := event
+										eventIndex := indexOf(event, eventCodes)
+										if eventIndex >= 0 {
+											if len(perlEventCodes) > eventIndex {
+												finalEvent = perlEventCodes[eventIndex]
+											}
+										}
+
+										if finalEvent == "evt.event_id" {
+											continue
+										}
+
+										// remove events that aren't all upper (for perl)
+										if !IsUpper(event) {
+											continue
+										}
+
+										// remove duplicates from results
+										hasEvent := false
+										for _, p := range perlEvents {
+											if p.EventIdentifier == finalEvent && p.EntityType == eventSubtype {
+												hasEvent = true
+												break
+											}
+										}
+										if hasEvent {
+											continue
+										}
+
+										fmt.Println("EntityType [%s] EventName [%s]", eventSubtype, event)
+										perlEvents = append(
+											perlEvents, PerlEvent{
+												EntityType:      eventSubtype,
+												EventName:       event,
+												EventIdentifier: finalEvent,
+												EventVars:       []string{},
+											},
+										)
+									}
 								}
 							}
 						}
@@ -292,4 +309,29 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 	}
 
 	return perlEvents
+}
+
+func getSpecialEventTypes(eventType string) []string {
+	if eventType == "BotMerc" {
+		return []string{"Bot", "Merc"}
+	} else if eventType == "BotMercNPC" {
+		return []string{"Bot", "Merc", "NPC"}
+	} else if eventType == "MercNPC" {
+		return []string{"Merc", "NPC"}
+	} else if eventType == "Mob" {
+		return []string{"Bot", "Merc", "NPC", "Player"}
+	}
+
+	return []string{eventType}
+}
+
+func isSpecialEventType(eventType string) bool {
+	specialEventTypes := []string{"BotMerc", "BotMercNPC", "MercNPC", "Mob"}
+	for _, specialEventType := range specialEventTypes {
+		if eventType == specialEventType {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/questapi/file_parse_perl_events.go
+++ b/internal/questapi/file_parse_perl_events.go
@@ -309,28 +309,3 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 
 	return perlEvents
 }
-
-func getSpecialEventTypes(eventType string) []string {
-	if eventType == "BotMerc" {
-		return []string{"Bot", "Merc"}
-	} else if eventType == "BotMercNPC" {
-		return []string{"Bot", "Merc", "NPC"}
-	} else if eventType == "MercNPC" {
-		return []string{"Merc", "NPC"}
-	} else if eventType == "Mob" {
-		return []string{"Bot", "Merc", "NPC", "Player"}
-	}
-
-	return []string{eventType}
-}
-
-func isSpecialEventType(eventType string) bool {
-	specialEventTypes := []string{"BotMerc", "BotMercNPC", "MercNPC", "Mob"}
-	for _, specialEventType := range specialEventTypes {
-		if eventType == specialEventType {
-			return true
-		}
-	}
-
-	return false
-}

--- a/internal/questapi/file_parse_perl_events.go
+++ b/internal/questapi/file_parse_perl_events.go
@@ -289,7 +289,6 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 											continue
 										}
 
-										fmt.Println("EntityType [%s] EventName [%s]", eventSubtype, event)
 										perlEvents = append(
 											perlEvents, PerlEvent{
 												EntityType:      eventSubtype,

--- a/internal/questapi/util.go
+++ b/internal/questapi/util.go
@@ -31,3 +31,28 @@ func IsUpper(s string) bool {
 	}
 	return true
 }
+
+func getSpecialEventTypes(eventType string) []string {
+	if eventType == "BotMerc" {
+		return []string{"Bot", "Merc"}
+	} else if eventType == "BotMercNPC" {
+		return []string{"Bot", "Merc", "NPC"}
+	} else if eventType == "MercNPC" {
+		return []string{"Merc", "NPC"}
+	} else if eventType == "Mob" {
+		return []string{"Bot", "Merc", "NPC", "Player"}
+	}
+
+	return []string{eventType}
+}
+
+func isSpecialEventType(eventType string) bool {
+	specialEventTypes := []string{"BotMerc", "BotMercNPC", "MercNPC", "Mob"}
+	for _, specialEventType := range specialEventTypes {
+		if eventType == specialEventType {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
- Fixes an issue where events using `BotMerc`, `BotMercNPC`, `MercNPC`, or `Mob` parse methods were showing under these general names instead of showing under the specific types.