### PR TITLE
[Launcher] Fix concurrent map writes under extreme edge cases

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -4,7 +4,7 @@
 # . or absolute path, please note that the directories following must be under root.
 root = "."
 # tmp_dir = "/tmp/"
-
+# root = "/home/eqemu/spire"
 [build]
 # Just plain old shell command. You could use `make` as well.
 
@@ -13,6 +13,10 @@ cmd = "go build -o /tmp/bin/app ."
 bin = "/bin/main"
 # Customize binary.
 full_bin = "APP_ENV=local /tmp/bin/app http:serve --port=3010"
+# Web backend development (default)
+# full_bin = "APP_ENV=local /tmp/bin/app http:serve --port=3010"
+# Launcher development
+# full_bin = "APP_ENV=local /tmp/bin/app eqemu-server:launcher start"
 # Watch these filename extensions.
 include_ext = ["go", "tpl", "tmpl", "html", "md", "json", "env"]
 # Ignore these filename extensions or directories.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [4.12.0] 1/1/2025
+
+* **Spire Admin** Improve resiliency within the Launcher and fix concurrent map writes under extreme edge cases.
+
 ## [4.11.2] 12/27/2024
 
 * **Spire Admin** Fix issue where the crash log watcher would display partial contents

--- a/internal/eqemuserver/launcher.go
+++ b/internal/eqemuserver/launcher.go
@@ -163,8 +163,8 @@ func (l *Launcher) Process() {
 		}
 
 		// variable sleep time based on the number of processes running
-		if l.currentProcessCounts[zoneProcessName] > 0 {
-			cnt := l.currentProcessCounts[zoneProcessName]
+		cnt := l.getProcessCounts(zoneProcessName)
+		if cnt > 0 {
 			if cnt > 1000 {
 				l.processSleepTime = 10 * time.Second
 			} else if cnt > 500 {
@@ -503,7 +503,7 @@ func (l *Launcher) Supervisor() error {
 	}
 
 	// boot world process if needed
-	if l.currentProcessCounts[worldProcessName] == 0 {
+	if l.getProcessCounts(worldProcessName) == 0 {
 		l.logger.Info().Msg("Starting World")
 		err := l.startServerProcess(worldProcessName)
 		if err != nil {
@@ -512,7 +512,7 @@ func (l *Launcher) Supervisor() error {
 	}
 
 	// boot loginserver if needed
-	if l.runLoginserver && l.currentProcessCounts[loginServerProcessName] == 0 {
+	if l.runLoginserver && l.getProcessCounts(loginServerProcessName) == 0 {
 		l.logger.Info().Msg("Starting Loginserver")
 		err := l.startServerProcess(loginServerProcessName)
 		if err != nil {
@@ -521,7 +521,7 @@ func (l *Launcher) Supervisor() error {
 	}
 
 	// boot queryserv if needed
-	if l.runQueryServ && l.currentProcessCounts[queryServProcessName] == 0 {
+	if l.runQueryServ && l.getProcessCounts(queryServProcessName) == 0 {
 		l.logger.Info().Msg("Starting QueryServ")
 		err := l.startServerProcess(queryServProcessName)
 		if err != nil {
@@ -530,7 +530,7 @@ func (l *Launcher) Supervisor() error {
 	}
 
 	// boot ucs if needed
-	if l.runUcs && l.currentProcessCounts[ucsProcessName] == 0 {
+	if l.runUcs && l.getProcessCounts(ucsProcessName) == 0 {
 		l.logger.Info().Msg("Starting UCS")
 		err := l.startServerProcess(ucsProcessName)
 		if err != nil {
@@ -592,19 +592,19 @@ func (l *Launcher) Supervisor() error {
 			Msg("Supervisor - Booting static zone(s)")
 	}
 
-	l.bootedTotalDynamics = l.currentProcessCounts[zoneProcessName] - l.currentZoneStatics
+	l.bootedTotalDynamics = l.getProcessCounts(zoneProcessName) - l.currentZoneStatics
 	l.targetDynamics = l.zoneAssignedDynamics + l.minZoneProcesses
 
 	// boot dynamics if needed
 	if !l.isDistributedRoot {
-		for l.currentProcessCounts[zoneProcessName]-l.currentZoneStatics < (l.zoneAssignedDynamics + l.minZoneProcesses) {
+		for l.getProcessCounts(zoneProcessName)-l.currentZoneStatics < (l.zoneAssignedDynamics + l.minZoneProcesses) {
 			// we don't want to start dynamic zone processes normally when distributed mode is enabled
 			err := l.startServerProcess(zoneProcessName)
 			if err != nil {
 				return err
 			}
 
-			l.bootedTotalDynamics = l.currentProcessCounts[zoneProcessName] - l.currentZoneStatics
+			l.bootedTotalDynamics = l.getProcessCounts(zoneProcessName) - l.currentZoneStatics
 			l.targetDynamics = l.zoneAssignedDynamics + l.minZoneProcesses
 
 			l.logger.Info().
@@ -621,7 +621,6 @@ func (l *Launcher) Supervisor() error {
 
 	l.logger.DebugVv().
 		Any("took", time.Now().Sub(now).String()).
-		Any("currentProcessCounts", l.currentProcessCounts).
 		Any("currentZoneDynamics", l.currentZoneDynamics).
 		Any("currentZoneStatics", l.currentZoneStatics).
 		Any("zoneAssignedDynamics", l.zoneAssignedDynamics).
@@ -1437,4 +1436,11 @@ func (l *Launcher) isLauncherDistributedModeLeaf() bool {
 	}
 
 	return false
+}
+
+func (l *Launcher) getProcessCounts(name string) int {
+	l.pollProcessMutex.Lock()
+	count := l.currentProcessCounts[name]
+	l.pollProcessMutex.Unlock()
+	return count
 }

--- a/internal/eqemuserver/launcher.go
+++ b/internal/eqemuserver/launcher.go
@@ -83,9 +83,10 @@ type Launcher struct {
 	zoneAssignedDynamics int
 
 	// mutexes
-	pollProcessMutex sync.Mutex
-	nodesMutex       sync.Mutex
-	configMutex      sync.Mutex
+	pollProcessMutex  sync.Mutex
+	nodesMutex        sync.Mutex
+	configMutex       sync.Mutex
+	setZoneCountMutex sync.Mutex
 }
 
 func NewLauncher(

--- a/internal/eqemuserver/launcher_process_unix.go
+++ b/internal/eqemuserver/launcher_process_unix.go
@@ -23,7 +23,9 @@ func (l *Launcher) startServerProcess(name string, args ...string) error {
 		return err
 	}
 
+	l.pollProcessMutex.Lock()
 	l.currentProcessCounts[name]++
+	l.pollProcessMutex.Unlock()
 
 	// we do this otherwise we get a zombie process
 	go func() {

--- a/internal/eqemuserver/launcher_process_windows.go
+++ b/internal/eqemuserver/launcher_process_windows.go
@@ -45,7 +45,9 @@ func (l *Launcher) startServerProcess(name string, args ...string) error {
 		return err
 	}
 
+	l.pollProcessMutex.Lock()
 	l.currentProcessCounts[name]++
+	l.pollProcessMutex.Unlock()
 
 	// we do this otherwise we get a zombie process
 	go func() {

--- a/internal/eqemuserver/launcher_rpc_server.go
+++ b/internal/eqemuserver/launcher_rpc_server.go
@@ -228,6 +228,9 @@ func (l *Launcher) rpcSetZoneCount(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, echo.Map{"error": first(err.Error())})
 	}
 
+	l.setZoneCountMutex.Lock()
+	defer l.setZoneCountMutex.Unlock()
+
 	// if node was just registered with no zone servers, check to see if we need to start shared memory
 	currentZoneCount := 0
 	processes, _ := process.Processes()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spire",
-  "version": "4.11.2",
+  "version": "4.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Akkadius/spire.git"


### PR DESCRIPTION
This PR introduces more concurrency safety to both reads and writes of the process counts map that is core to launcher functionality.

## [4.12.0] 1/1/2025

* **Spire Admin** Improve resiliency within the Launcher and fix concurrent map writes under extreme edge cases.

### Testing

**Distributed Launcher**

Everything worked well, zones booted as expected

![image](https://github.com/user-attachments/assets/c21ab727-d68b-4c60-97b7-a661018121fc)

**Standalone Launcher** (Majority of users)

Everything worked as expected.

![image](https://github.com/user-attachments/assets/b2ad177c-33dc-407e-bcd9-8b83d4e4eb6b)

**Crash**

Concurrent map writes under extremely rare circumstances.

```bash
fatal error: concurrent map writes

goroutine 1 [running]:
github.com/Akkadius/spire/internal/eqemuserver.(*Launcher).pollProcessCounts(0xc000121980)
	/drone/src/internal/eqemuserver/launcher.go:1403 +0x77c
github.com/Akkadius/spire/internal/eqemuserver.(*Launcher).Supervisor(0xc000121980)
	/drone/src/internal/eqemuserver/launcher.go:498 +0x5b
github.com/Akkadius/spire/internal/eqemuserver.(*Launcher).Process(0xc000121980)
	/drone/src/internal/eqemuserver/launcher.go:159 +0x6af
github.com/Akkadius/spire/internal/eqemuserver.(*LauncherCmd).Handle(0xc001bc33b0, 0x0?, {0xc001be0c60, 0x1, 0x0?})
	/drone/src/internal/eqemuserver/launcher_cmd.go:56 +0x198
github.com/spf13/cobra.(*Command).execute(0xc001bec500, {0xc001be0c30, 0x1, 0x1})
	/home/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:876 +0x67b
github.com/spf13/cobra.(*Command).ExecuteC(0xc001becf00)
	/home/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:990 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/home/go/pkg/mod/github.com/spf13/cobra@v1.5.0/command.go:918
github.com/Akkadius/spire/internal/console.Run({0xc000196f20, 0x15, 0x15})
	/drone/src/internal/console/bootstrap.go:13 +0x73
main.main()
	/drone/src/main.go:59 +0x1f0
```
