### PR TITLE
[Spells] Spell Editor Fixes

### DIFF
--- a/frontend/src/app/constants/eq-spell-constants.ts
+++ b/frontend/src/app/constants/eq-spell-constants.ts
@@ -764,7 +764,7 @@ export const DB_SPELL_TYPES = {
 }
 
 export const DB_SPELL_RESISTS = {
-  "0": "None",
+  "0": "Unresistable",
   "1": "Magic",
   "2": "Fire",
   "3": "Cold",
@@ -956,7 +956,7 @@ export const DB_SPELL_TARGET_RESTRICTION = {
   "815": "Is Treant",
   "816": "Is Bixie2",
   "817": "Is Scarecrow",
-  "": "Is Vampire Or Undead Or Undeadpet",
+  "818": "Is Vampire Or Undead Or Undeadpet",
   "819": "Is Not Vampire Or Undead",
   "820": "Is Class Knight Hybrid Melee",
   "821": "Is Class Warrior Caster Priest",
@@ -1415,8 +1415,8 @@ export const BUFF_DURATION_FORMULAS = {
   13: 'Unknown',
   14: 'Unknown',
   15: 'Unknown',
-  50: '5 Days',
-  51: 'Permanent',
+  50: 'Permanent',
+  51: 'Aura',
   3600: 'Duration if not 0, else 3600',
 };
 

--- a/frontend/src/components/preview/EQSpellCardPreview.vue
+++ b/frontend/src/components/preview/EQSpellCardPreview.vue
@@ -298,7 +298,7 @@
       </tr>
       <tr v-else>
         <td class="spell-field-label">Resist Type</td>
-        <td> Unresistable</td>
+        <td>Unresistable</td>
       </tr>
       <tr v-if="spellData['max_resist'] > 0 || spellData['min_resist'] > 0">
         <td class="spell-field-label">Resist Chance Limits</td>

--- a/frontend/src/components/preview/EQSpellCardPreview.vue
+++ b/frontend/src/components/preview/EQSpellCardPreview.vue
@@ -197,12 +197,12 @@
 
       <!-- Duration / Buffs -->
 
-      <tr v-if="getBuffDuration(spellData)">
+      <tr v-if="spellData['buffduration']">
         <td class="spell-field-label">Duration</td>
         <td> {{ humanTime(getBuffDuration(spellData) * 6) }} - {{ getBuffDuration(spellData) }} tic(s)</td>
       </tr>
 
-      <tr v-if="getBuffDuration(spellData)">
+      <tr>
         <td class="spell-field-label">Dispelable</td>
         <td>
           <span v-if="spellData['dispel_flag'] !== 0">No</span>
@@ -294,8 +294,11 @@
           > &nbsp;({{
               spellData["resist_diff"]
             }}) &nbsp; (No Partial Resist)</span>
-          <span v-if="spellData['field_209'] !== 0">(Unresistable)</span>
         </td>
+      </tr>
+      <tr v-else>
+        <td class="spell-field-label">Resist Type</td>
+        <td> Unresistable</td>
       </tr>
       <tr v-if="spellData['max_resist'] > 0 || spellData['min_resist'] > 0">
         <td class="spell-field-label">Resist Chance Limits</td>

--- a/frontend/src/components/preview/EQSpellPreviewTable.vue
+++ b/frontend/src/components/preview/EQSpellPreviewTable.vue
@@ -107,7 +107,8 @@
             <td>{{ spell["mana"] > 0 ? spell["mana"] : "" }}</td>
             <td> {{ (spell["cast_time"] / 1000) }} sec</td>
             <td> {{ (spell["recast_time"] / 1000) }} sec</td>
-            <td> {{ humanTime(getBuffDuration(spell) * 6) }} {{ getBuffDuration(spell) }} tic(s)</td>
+            <td v-if="spell['buffduration']"> {{ humanTime(getBuffDuration(spell) * 6) }} {{ getBuffDuration(spell) }} tic(s)</td>
+            <td v-else>N/A</td>
             <td> {{ getTargetTypeName(spell["targettype"]) }}</td>
 
 

--- a/frontend/src/views/spells/SpellEditor.vue
+++ b/frontend/src/views/spells/SpellEditor.vue
@@ -1213,11 +1213,6 @@
                 class="row" v-for="field in
                      [
                        {
-                         description: 'Unresistable',
-                         field: 'field_209',
-                         bool: true
-                       },
-                       {
                          description: 'No Partial Resists',
                          field: 'no_partial_resist',
                          bool: true

--- a/frontend/src/views/spells/SpellEditor.vue
+++ b/frontend/src/views/spells/SpellEditor.vue
@@ -1200,7 +1200,7 @@
                   @click="processClickInputTrigger(field.field)"
                 >
                   <!-- Modifier description -->
-                  <div v-if="['buffduration'].includes(field.field)" style="margin-top: 8px">
+                  <div v-if="['buffduration'].includes(field.field) && buffduration > 0" style="margin-top: 8px">
                     {{ humanTime(getBuffDuration(spell) * 6) }} - {{ getBuffDuration(spell) }} tic(s)
                   </div>
                 </div>


### PR DESCRIPTION
## Description
Adjust spell editor to account for proper unresistable flag and duration formulas. Also fix missing spell constant in target restrictions.
Fixes #123

### Resists
Spell 1042 Before:
![image](https://github.com/user-attachments/assets/ac2556a7-140b-4b25-aa79-0e32adea02d0)
![image](https://github.com/user-attachments/assets/935b8d3e-bb47-4d85-90be-22e2622bb4fc)

Spell 1042 After:
![image](https://github.com/user-attachments/assets/eacf3b6b-fc88-442f-b8bf-576728e217ca)
![image](https://github.com/user-attachments/assets/fac1b0f4-539e-4489-a52e-5f511571a48d)


Spell 5874 Before:
![image](https://github.com/user-attachments/assets/b559da8a-8b3a-4e2e-9b16-ab964d692c02)
![image](https://github.com/user-attachments/assets/af844f48-794b-46aa-b5f4-b28804575cac)

Spell 5874 After:
![image](https://github.com/user-attachments/assets/ce664fd7-d425-4d81-bcea-a311372f17fc)


### Buff Duration Formulas
Spell 5874 Before:
![image](https://github.com/user-attachments/assets/390325c5-a0ac-4a00-9911-dcba38a4fe06)
![image](https://github.com/user-attachments/assets/ddecdd07-2561-4100-9ff2-17c1ea436cf4)

Spell 5874 After:
![image](https://github.com/user-attachments/assets/9ed4f849-b204-4c1a-860c-ccd97081b228)


Spell 6720 Before:
![image](https://github.com/user-attachments/assets/88134366-df11-4634-b227-75849d6fb8cc)
![image](https://github.com/user-attachments/assets/de1f4795-5ad6-49d2-8230-de7dbb4cb45d)
![image](https://github.com/user-attachments/assets/212530eb-d047-4749-ba7b-19a395a81706)

Spell 6720 After:
![image](https://github.com/user-attachments/assets/462e71c7-d709-4898-9728-9944ec660b87)
![image](https://github.com/user-attachments/assets/2f3e73cc-b069-4a4e-8dc0-79e417eac12e)
![image](https://github.com/user-attachments/assets/99700972-cbcf-4264-8481-4abc93e9f640)

