### PR TITLE
[NPC Spells] Fix Resist Adjust

### DIFF
--- a/frontend/src/views/npcs/NpcSpellListEditor.vue
+++ b/frontend/src/views/npcs/NpcSpellListEditor.vue
@@ -296,7 +296,7 @@ export default {
         { desc: "Maximum Level", field: "maxlevel", fType: "number" },
         { desc: "Min HP", field: "min_hp", fType: "number" },
         { desc: "Max HP", field: "max_hp", fType: "number" },
-        { desc: "Resist Adjust", field: "resist_adjust", fType: "text" },
+        { desc: "Resist Adjust", field: "resist_adjust", fType: "number" },
       ],
     }
   },


### PR DESCRIPTION
Fixes the `Resist Adjust` part of the NPC Spell Editor. Data type was set to `text` when it should have been `number`.

Fixes #155

Before:
![image](https://github.com/user-attachments/assets/a444cc3c-bf9c-49db-8170-914886908492)

After:
![image](https://github.com/user-attachments/assets/50fb5518-5f1e-4614-ba9b-04892a403ea5)