### PR TITLE
[Spells] Fix `buffduration` tweak

### DIFF
--- a/frontend/src/views/spells/SpellEditor.vue
+++ b/frontend/src/views/spells/SpellEditor.vue
@@ -1200,7 +1200,7 @@
                   @click="processClickInputTrigger(field.field)"
                 >
                   <!-- Modifier description -->
-                  <div v-if="['buffduration'].includes(field.field) && buffduration > 0" style="margin-top: 8px">
+                  <div v-if="['buffduration'].includes(field.field) && spell.buffduration > 0" style="margin-top: 8px">
                     {{ humanTime(getBuffDuration(spell) * 6) }} - {{ getBuffDuration(spell) }} tic(s)
                   </div>
                 </div>


### PR DESCRIPTION
Fixes `buffduration` error introduced in #205

```
[Vue warn]: Property or method "buffduration" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://v2.vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.

found in

---> <SpellEdit> at src/views/spells/SpellEditor.vue
       <ContentArea> at src/components/layout/ContentArea.vue
         <MainLayout> at src/components/layout/MainLayout.vue
           <App> at src/App.vue
             <Root>
```