### PR TITLE
[Tasks] Update Touch Activity for DZ Switch

### DIFF
--- a/frontend/src/views/tasks/TaskEditor.vue
+++ b/frontend/src/views/tasks/TaskEditor.vue
@@ -598,6 +598,15 @@
                              field: 'goalcount',
                              fieldType: 'number',
                              col: 'col-2',
+                             showIf: !isTouchActivityActive()
+                           },
+                           {
+                             description: 'DZ Switch ID',
+                             itemIcon: '3196',
+                             field: 'dz_switch_id',
+                             fieldType: 'number',
+                             col: 'col-2',
+                             showIf: isTouchActivityActive()
                            },
                            {
                              description: 'Quest Controlled',
@@ -1536,6 +1545,14 @@ export default {
     isGoalIdExploreActive() {
       return [
         TASK_ACTIVITY_TYPE.EXPLORE,
+      ].includes(
+        parseInt(this.task.task_activities[this.selectedActivity].activitytype)
+      )
+    },
+
+    isTouchActivityActive() {
+      return [
+        TASK_ACTIVITY_TYPE.TOUCH,
       ].includes(
         parseInt(this.task.task_activities[this.selectedActivity].activitytype)
       )


### PR DESCRIPTION
When the `Touch` activity (11) is active, the `DZ Switch ID` should be active.

Before:
![image](https://github.com/user-attachments/assets/685e26af-ffe5-4753-b127-212606a72728)

After:
![image](https://github.com/user-attachments/assets/2538b003-0d95-4117-9496-5f38ea2a6d3f)

Goal Count Restored:
![image](https://github.com/user-attachments/assets/91ddb547-5577-4e04-a242-33bb52a86c30)
