### PR TITLE
[Spells] Better support for teleport spells

### DIFF
--- a/frontend/src/views/spells/SpellEditor.vue
+++ b/frontend/src/views/spells/SpellEditor.vue
@@ -288,7 +288,7 @@
                          description: teleportZoneFieldName,
                          field: 'teleport_zone',
                          text: true,
-                         showIf: teleportZoneFieldName !== ''
+                         showIf: teleportZoneFieldName !== '' || spell['effectid_1'] == 83
                        },
                      ]"
                 v-if="typeof field.showIf === 'undefined' || (typeof field.showIf !== 'undefined' && field.showIf) || showAllFields"
@@ -1913,7 +1913,7 @@ export default {
           this.spell['teleport_zone'] = selectedZone.short_name
           EditFormFieldUtil.setFieldModifiedById("teleport_zone")
 
-          // make revelant slots visible when a zone is selected
+          // make relevant slots visible when a zone is selected
           for (let slot = effectIndex; slot < (effectIndex + 4); slot++) {
             this.visibleEffectSlots[slot] = true
             this.$forceUpdate()
@@ -2270,7 +2270,7 @@ export default {
 
           // visible slots effectid 1-12
           for (let i = 1; i <= 12; i++) {
-            if (this.spell["effectid_" + i] !== 254) {
+            if (this.spell["effectid_" + i] !== 254 || (this.spell["effectid_1"] == 83 && i <= 4)) {
               this.visibleEffectSlots[i] = true
             }
           }


### PR DESCRIPTION
By default, teleport spells (83) would only show the first effect while hiding the other 3 coordinate entries. This enables all coordinate fields for teleport spells.
Additionally, when selecting the teleport effect, the zone selector field would not appear by default.

Before:
![image](https://github.com/user-attachments/assets/fe2013da-9a55-47f9-9513-309f76a1215b)
![image](https://github.com/user-attachments/assets/218073df-2bb2-4666-8a8e-6a86e5d70ab8)


After:
![image](https://github.com/user-attachments/assets/2e3b950e-aaaf-40bc-956d-342d3ce416fc)
![image](https://github.com/user-attachments/assets/0d6c2210-5cf3-42f5-ad0a-4cef7720d5fe)
