### PR TITLE
[Bug Fix] Fix Zone Controller Event Parsing

### DIFF
--- a/internal/questapi/file_parse_perl_events.go
+++ b/internal/questapi/file_parse_perl_events.go
@@ -120,6 +120,29 @@ func (c *ParseService) parsePerlEvents(files map[string]string) []PerlEvent {
 								},
 							)
 						}
+					} else if strings.Contains(l, "DispatchZoneControllerEvent") {
+						fmt.Printf("In [DispatchZoneControllerEvent] check")
+						if strings.Contains(l, "DispatchZoneControllerEvent") && strings.Contains(l, "EVENT_") {
+							entity := "NPC"
+							event := ""
+
+							// @eg DispatchZoneControllerEvent(EVENT_DEATH_ZONE, owner_or_self, export_string, 0, &args);
+							// @result EVENT_DEATH_ZONE
+							eventSplit := strings.Split(l, "(EVENT_")
+							if len(eventSplit) > 1 {
+								eventSplit2 := strings.Split(eventSplit[1], ",")
+								if len(eventSplit2) > 0 {
+									event = "EVENT_" + strings.TrimSpace(eventSplit2[0])
+								}
+							}
+
+							eventEntityMappings = append(
+								eventEntityMappings, PerlEventEntityMapping{
+									Entity: entity,
+									Event:  event,
+								},
+							)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Fixes an issue where zone controller events are sent with `DispatchZoneControllerEvent` and thus not properly parsed into the event listing.